### PR TITLE
CA wait after setting velocity so move has new velocity every time

### DIFF
--- a/ReflectometryServer/pv_wrapper.py
+++ b/ReflectometryServer/pv_wrapper.py
@@ -316,7 +316,7 @@ class PVWrapper:
             value (float): The value to set
         """
         logger.info("{}: Setting velocity to : {}".format(self.name, value))
-        self._write_pv(self._velo_pv, value)
+        self._write_pv(self._velo_pv, value, wait=True)
 
     @property
     def max_velocity(self):


### PR DESCRIPTION
Some tests fail because the motor velocities don't seem to get set before a move. I ave added a wait in, I can't think why this would be detrimental and all the tests still pass on my machine. Before doing this runing:

```
cd support\IocTestFramework\master
%PYTHON% run_tests.py -t refl.ReflTests.test_GIVEN_PNR_mode_with_SM_angle_WHEN_move_in_disable_mode_and_into_PNR_THEN_beamline_is_updated_on_mode_change_and_value_of_pd_offsets_correct
```
failed everytime now it doesn't, but it might just be on my machine where the velocity on MOT0107 seems to be set low but max velocity is high.

