### PR TITLE
Only update relevant refl PVs

### DIFF
--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -83,12 +83,16 @@ RBV_AT_SP = ":RBV:AT_SP"
 CHANGING = ":CHANGING"
 CHANGED_SUFFIX = ":CHANGED"
 DEFINE_POSITION_AS = ":DEFINE_POSITION_AS"
-CONST_PREFIX = "CONST"
 
 VAL_FIELD = ".VAL"
 STAT_FIELD = ".STAT"
 SEVR_FIELD = ".SEVR"
 DESC_FIELD = ".DESC"
+
+ALL_PARAM_SUFFIXES = [VAL_FIELD, STAT_FIELD, SEVR_FIELD, DESC_FIELD, SP_SUFFIX, SP_RBV_SUFFIX, SET_AND_NO_ACTION_SUFFIX,
+                      CHANGED_SUFFIX, ACTION_SUFFIX, CHANGING, IN_MODE_SUFFIX, RBV_AT_SP]
+
+CONST_PREFIX = "CONST"
 
 FOOTPRINT_PREFIX = "FP"
 SAMPLE_LENGTH = "{}:{}".format(FOOTPRINT_PREFIX, "SAMPLE_LENGTH")
@@ -447,6 +451,32 @@ class PVManager:
             (str, PvSort): parameter name and sort for the given pv
         """
         return self._params_pv_lookup[self.strip_fields_from_pv(pv_name)]
+
+    def _get_base_param_pv(self, pv_name):
+        """
+        Args:
+            pv_name: name of pv for which to get the base pv
+
+        Returns:
+            (str): base parameter pv stripped of any fields / suffixes
+        """
+        for field in ALL_PARAM_SUFFIXES:
+            pv_name = remove_from_end(pv_name, field)
+        return pv_name
+
+    def get_all_pvs_for_param(self, pv_name):
+        """
+        Get a list of all suffixed PVs for a given parameter.
+
+        Args:
+            pv_name: name of pv for which to get the list of PVs
+
+        Returns:
+            (list[str]): The list of all PVs related to this parameter
+        """
+        base_pv = self._get_base_param_pv(pv_name)
+        all_pvs = [base_pv] + [(base_pv + suffix) for suffix in ALL_PARAM_SUFFIXES]
+        return all_pvs
 
     def strip_fields_from_pv(self, pv_name):
         """

--- a/ReflectometryServer/ChannelAccess/reflectometry_driver.py
+++ b/ReflectometryServer/ChannelAccess/reflectometry_driver.py
@@ -230,7 +230,8 @@ class ReflectometryDriver(Driver):
         pv_name, value, alarm_severity, alarm_status = \
             self._driver_help.get_param_update_from_event(pv_name, param_type, update)
         self._update_param_both_pv_and_pv_val(pv_name, value, alarm_severity, alarm_status)
-        self.updatePVs()
+        for pv in self._pv_manager.get_all_pvs_for_param(pv_name):
+            self.updatePV(pv)
 
     def add_param_listeners(self):
         """
@@ -253,7 +254,8 @@ class ReflectometryDriver(Driver):
 
     def _update_binary_listener(self, pv_name, update):
         self.setParam(pv_name, update.value)
-        self.updatePVs()
+        for pv in self._pv_manager.get_all_pvs_for_param(pv_name):
+            self.updatePV(pv)
 
     def _on_bl_mode_change(self, mode_update):
         """
@@ -274,7 +276,7 @@ class ReflectometryDriver(Driver):
         self._update_param_both_pv_and_pv_val(BEAMLINE_MODE + SP_SUFFIX, mode_value)
         self.updatePVs()
 
-    def _on_server_status_change(self, update):
+    def _on_server_status_change(self, update: StatusUpdate):
         """
         Update the overall status of the beamline.
 
@@ -287,7 +289,7 @@ class ReflectometryDriver(Driver):
         self._update_param_both_pv_and_pv_val(SERVER_MESSAGE, update.server_message)
         self.updatePVs()
 
-    def _on_error_log_update(self, update: StatusUpdate):
+    def _on_error_log_update(self, update: ErrorLogUpdate):
         """
         Update the overall status of the beamline.
 


### PR DESCRIPTION
Sped up processing of motor RBV events by the reflectometry server. Profiling the event handler revealed that most of the time was spent updating top-level reflectometry server PVs. As any change in RBV for any parameter triggered updates for every PV in the server, the number of calls exploded exponentially. 

With these changes, the listener responsible for updating reflectometry server PVs only updates PVs relevant to an event's source parameter. Using the POLREF configuration, on moving the bench offset (where we originally observed this bug on POLREF), this has reduced 
- the number of calls of `updatePV` from 377280 to 1248 
- the amount of time taken to process an RBV event from 0.485 to 0.073s


A spreadsheet with the full results from cProfile is in the private shared folder under `/reflectometry/Ticket5742`. If you want to run the profiler yourself, in `pv_wrapper.py` replace 
- l. 76: 
```
# threading.Thread(target=self.process_triggers_loop).start()
self.process_triggers_loop()
```
- l. 475:
```
# PROCESS_MONITOR_EVENTS.add_trigger(self.trigger_listeners, ReadbackUpdate(new_value, alarm_severity, alarm_status)) 
cProfile.runctx('PROCESS_MONITOR_EVENTS.add_trigger(self.trigger_listeners, ReadbackUpdate(new_value, alarm_severity, alarm_status))', globals=globals(), locals=locals())
```

Ticket: https://github.com/ISISComputingGroup/IBEX/issues/5742