### PR TITLE
Axis out of beam still moves if component as a whole is not

### DIFF
--- a/ReflectometryServer/ioc_driver.py
+++ b/ReflectometryServer/ioc_driver.py
@@ -315,16 +315,18 @@ class IocDriver:
         """
         Returns: position that the set point axis is set to
         """
-        if self._component.beam_path_set_point.axis[self._component_axis].is_in_beam:
+        if self._component.beam_path_set_point.is_in_beam:
             displacement = self._component.beam_path_set_point.axis[self._component_axis].get_displacement()
         else:
             if self._out_of_beam_lookup is None:
                 displacement = 0
-                STATUS_MANAGER.update_error_log(
-                    "The component {} is out of the beam but there is no out of beam position for the driver "
-                    "running motor_axis {}".format(self._component.name, self._motor_axis.name))
-                STATUS_MANAGER.update_active_problems(
-                    ProblemInfo("No out of beam position defined for motor_axis", self.name, Severity.MINOR_ALARM))
+                if not self._component.beam_path_set_point.axis[self._component_axis].is_in_beam:
+                    STATUS_MANAGER.update_error_log(
+                        "An axis for component {} is set to out of beam but there is no out of beam position defined "
+                        "for the driver for the associated motor axis {}".format(self._component.name,
+                                                                                 self._motor_axis.name))
+                    STATUS_MANAGER.update_active_problems(
+                        ProblemInfo("No out of beam position defined for motor_axis", self.name, Severity.MINOR_ALARM))
             else:
                 beam_interception = self._component.beam_path_set_point.calculate_beam_interception()
                 out_of_beam_position = self._out_of_beam_lookup.get_position_for_intercept(beam_interception)

--- a/ReflectometryServer/ioc_driver.py
+++ b/ReflectometryServer/ioc_driver.py
@@ -315,26 +315,24 @@ class IocDriver:
         """
         Returns: position that the set point axis is set to
         """
-        if self._component.beam_path_set_point.is_in_beam:
+        if not self._component.beam_path_set_point.axis[self._component_axis].is_in_beam \
+                and self._out_of_beam_lookup is None:
+            STATUS_MANAGER.update_error_log(
+                "An axis for component {} is set to out of beam but there is no out of beam position defined "
+                "for the driver for the associated motor axis {}".format(self._component.name, self._motor_axis.name))
+            STATUS_MANAGER.update_active_problems(
+                ProblemInfo("No out of beam position defined for motor_axis", self.name, Severity.MINOR_ALARM))
+
+        if self._component.beam_path_set_point.is_in_beam or self._out_of_beam_lookup is None:
             displacement = self._component.beam_path_set_point.axis[self._component_axis].get_displacement()
         else:
-            if self._out_of_beam_lookup is None:
-                displacement = 0
-                if not self._component.beam_path_set_point.axis[self._component_axis].is_in_beam:
-                    STATUS_MANAGER.update_error_log(
-                        "An axis for component {} is set to out of beam but there is no out of beam position defined "
-                        "for the driver for the associated motor axis {}".format(self._component.name,
-                                                                                 self._motor_axis.name))
-                    STATUS_MANAGER.update_active_problems(
-                        ProblemInfo("No out of beam position defined for motor_axis", self.name, Severity.MINOR_ALARM))
+            beam_interception = self._component.beam_path_set_point.calculate_beam_interception()
+            out_of_beam_position = self._out_of_beam_lookup.get_position_for_intercept(beam_interception)
+            if out_of_beam_position.is_offset:
+                displacement = self._component.beam_path_set_point.axis[self._component_axis].\
+                    get_displacement_for(out_of_beam_position.position)
             else:
-                beam_interception = self._component.beam_path_set_point.calculate_beam_interception()
-                out_of_beam_position = self._out_of_beam_lookup.get_position_for_intercept(beam_interception)
-                if out_of_beam_position.is_offset:
-                    displacement = self._component.beam_path_set_point.axis[self._component_axis].\
-                        get_displacement_for(out_of_beam_position.position)
-                else:
-                    displacement = out_of_beam_position.position
+                displacement = out_of_beam_position.position
         return displacement
 
     def _on_update_rbv(self, update):

--- a/ReflectometryServer/test_modules/test_beamline.py
+++ b/ReflectometryServer/test_modules/test_beamline.py
@@ -756,6 +756,25 @@ class TestComponentOutOfBeam(unittest.TestCase):
 
         assert_that(actual, is_(expected))
 
+    def test_GIVEN_component_partially_in_beam_WHEN_setting_new_setpoint_for_axis_out_of_beam_THEN_driver_moves(self):
+        out_of_beam_position = OutOfBeamPosition(self.OUT_OF_BEAM_VALUE)
+        chi_axis = create_mock_axis("chi", self.IN_BEAM_VALUE, 1)
+        psi_axis = create_mock_axis("psi", self.OUT_OF_BEAM_VALUE, 1)
+        chi_driver = IocDriver(self.comp, ChangeAxis.CHI, chi_axis, out_of_beam_positions=[out_of_beam_position])
+        psi_driver = IocDriver(self.comp, ChangeAxis.PSI, psi_axis, out_of_beam_positions=[out_of_beam_position])
+        chi_axis.sp = self.IN_BEAM_VALUE
+        psi_axis.sp = self.OUT_OF_BEAM_VALUE
+        chi_driver.initialise_setpoint()
+        psi_driver.initialise_setpoint()
+
+        expected = self.IN_BEAM_VALUE
+
+        self.comp.beam_path_set_point.axis[ChangeAxis.PSI].set_displacement(CorrectedReadbackUpdate(self.IN_BEAM_VALUE, None, None))
+        psi_driver.perform_move(1)
+        actual = psi_axis.sp
+
+        assert_that(actual, is_(expected))
+
     def test_GIVEN_component_with_axis_with_out_of_beam_position_WHEN_in_beam_sp_changes_THEN_only_axis_with_out_of_beam_position_marked_as_changed(self):
         out_of_beam_position = OutOfBeamPosition(self.OUT_OF_BEAM_VALUE)
         chi_axis = create_mock_axis("chi", self.IN_BEAM_VALUE, 1)


### PR DESCRIPTION
Fixed a bug where an axis which was out of beam could not be moved even if the component as a whole is still in beam

Ticket: https://github.com/ISISComputingGroup/IBEX/issues/5655