### PR TITLE
Do not restore velocity on init moving state

### DIFF
--- a/ReflectometryServer/pv_wrapper.py
+++ b/ReflectometryServer/pv_wrapper.py
@@ -483,7 +483,7 @@ class PVWrapper:
             alarm_severity (server_common.channel_access.AlarmSeverity): severity of any alarm
             alarm_status (server_common.channel_access.AlarmCondition): the alarm status
         """
-        if new_value == MTR_STOPPED:
+        if self._moving_state_cache is not None and new_value == MTR_STOPPED:
             self.restore_pre_move_velocity()
         self._moving_state_cache = new_value
 


### PR DESCRIPTION
Does not attempt to restore axis velocity when a moving state update is read on initialisation. (i.e. it is not actually a _change_ in state). This removes "velocity cannot be restored" errors previously seen on IOC startup.

Ticket: https://github.com/ISISComputingGroup/IBEX/issues/5650