### PR TITLE
Ticket 5781: Apply mode inits on move all

### DIFF
--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -117,7 +117,7 @@ def is_pv_name_this_field(field_name, pv_name):
         field_name: field name to match
         pv_name: pv name to match
 
-    Returns: True if field name is pv name (with oe without VAL  field)
+    Returns: True if field name is pv name (with oe without VAL field)
 
     """
     pv_name_no_val = remove_from_end(pv_name, VAL_FIELD)
@@ -507,56 +507,6 @@ class PVManager:
         return pv_name_no_val == BEAMLINE_MODE or pv_name_no_val == BEAMLINE_MODE + SP_SUFFIX
 
     @staticmethod
-    def is_beamline_move(pv_name):
-        """
-        Args:
-            pv_name: name of the pv
-
-        Returns: True if this the beamline move pv
-        """
-        return is_pv_name_this_field(BEAMLINE_MOVE, pv_name)
-
-    @staticmethod
-    def is_sample_length(pv_name):
-        """
-        Args:
-            pv_name: name of the pv
-
-        Returns: True if this the sample length pv
-        """
-        return is_pv_name_this_field(SAMPLE_LENGTH, pv_name)
-
-    @staticmethod
-    def is_server_status(pv_name):
-        """
-        Args:
-            pv_name: name of the pv
-
-        Returns: True if this the server status pv
-        """
-        return is_pv_name_this_field(SERVER_STATUS, pv_name)
-
-    @staticmethod
-    def is_server_message(pv_name):
-        """
-        Args:
-            pv_name: name of the pv
-
-        Returns: True if this the server message pv
-        """
-        return is_pv_name_this_field(SERVER_MESSAGE, pv_name)
-
-    @staticmethod
-    def is_error_log(pv_name):
-        """
-        Args:
-            pv_name: name of the pv
-
-        Returns: True if this the server error log pv
-        """
-        return is_pv_name_this_field(SERVER_ERROR_LOG, pv_name)
-
-    @staticmethod
     def is_alarm_status(pv_name):
         """
         Args:
@@ -575,13 +525,3 @@ class PVManager:
         Returns: True if this is an alarm severity pv
         """
         return pv_name.endswith(SEVR_FIELD)
-
-    @staticmethod
-    def is_reapply_mode_inits(pv_name):
-        """
-        Args:
-            pv_name: name of the pv
-
-        Returns: True if this the reapply mode inits pv
-        """
-        return is_pv_name_this_field(REAPPLY_MODE_INITS, pv_name)

--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -55,6 +55,7 @@ SERVER_MESSAGE = "MSG"
 SERVER_ERROR_LOG = "LOG"
 BEAMLINE_MODE = BEAMLINE_PREFIX + "MODE"
 BEAMLINE_MOVE = BEAMLINE_PREFIX + "MOVE"
+REAPPLY_MODE_INITS = BEAMLINE_PREFIX + "INIT_ON_MOVE"
 
 PARAM_INFO = "PARAM_INFO"
 PARAM_INFO_COLLIMATION = "COLLIM_INFO"
@@ -187,6 +188,9 @@ class PVManager:
         self._add_pv_with_fields(BEAMLINE_MODE, None, mode_fields, "Beamline mode", PvSort.RBV, archive=True,
                                  interest="HIGH")
         self._add_pv_with_fields(BEAMLINE_MODE + SP_SUFFIX, None, mode_fields, "Beamline mode", PvSort.SP)
+
+        self._add_pv_with_fields(REAPPLY_MODE_INITS, None, PARAM_FIELDS_BINARY, "Apply mode inits on move all", PvSort.RBV,
+                                 archive=True, interest="MEDIUM")
 
     def _add_footprint_calculator_pvs(self):
         """
@@ -571,3 +575,13 @@ class PVManager:
         Returns: True if this is an alarm severity pv
         """
         return pv_name.endswith(SEVR_FIELD)
+
+    @staticmethod
+    def is_reapply_mode_inits(pv_name):
+        """
+        Args:
+            pv_name: name of the pv
+
+        Returns: True if this the reapply mode inits pv
+        """
+        return is_pv_name_this_field(REAPPLY_MODE_INITS, pv_name)

--- a/ReflectometryServer/ChannelAccess/reflectometry_driver.py
+++ b/ReflectometryServer/ChannelAccess/reflectometry_driver.py
@@ -11,9 +11,9 @@ from pcaspy.driver import manager, Data
 from ReflectometryServer import Beamline
 from ReflectometryServer.ChannelAccess.constants import REFLECTOMETRY_PREFIX, REFL_IOC_NAME
 from ReflectometryServer.ChannelAccess.driver_utils import DriverParamHelper
-from ReflectometryServer.ChannelAccess.pv_manager import PvSort, BEAMLINE_MODE, VAL_FIELD, SERVER_STATUS, \
-    SERVER_MESSAGE, SP_SUFFIX, FP_TEMPLATE, DQQ_TEMPLATE, QMIN_TEMPLATE, QMAX_TEMPLATE, \
-    IN_MODE_SUFFIX, SERVER_ERROR_LOG
+from ReflectometryServer.ChannelAccess.pv_manager import PvSort, is_pv_name_this_field, BEAMLINE_MODE, VAL_FIELD, \
+    SERVER_STATUS, SERVER_MESSAGE, SP_SUFFIX, FP_TEMPLATE, DQQ_TEMPLATE, QMIN_TEMPLATE, QMAX_TEMPLATE, \
+    IN_MODE_SUFFIX, SERVER_ERROR_LOG, SAMPLE_LENGTH, REAPPLY_MODE_INITS, BEAMLINE_MOVE
 from ReflectometryServer.beamline import ActiveModeUpdate
 from ReflectometryServer.server_status_manager import STATUS_MANAGER, StatusUpdate, ProblemInfo, ErrorLogUpdate
 from ReflectometryServer.footprint_manager import FootprintSort
@@ -100,24 +100,24 @@ class ReflectometryDriver(Driver):
                 elif self._pv_manager.is_beamline_mode(reason):
                     return self._beamline_mode_value(self._beamline.active_mode)
 
-                elif self._pv_manager.is_beamline_move(reason):
+                elif is_pv_name_this_field(BEAMLINE_MOVE, reason):
                     return self._beamline.move
 
-                elif self._pv_manager.is_reapply_mode_inits(reason):
+                elif is_pv_name_this_field(REAPPLY_MODE_INITS, reason):
                     return self._beamline.reinit_mode_on_move
 
-                elif self._pv_manager.is_server_status(reason):
+                elif is_pv_name_this_field(SERVER_STATUS, reason):
                     beamline_status_enums = self._pv_manager.PVDB[SERVER_STATUS]["enums"]
                     new_value = beamline_status_enums.index(STATUS_MANAGER.status.display_string)
                     #  Set the value so that the error condition is set
                     self.setParam(reason, new_value)
                     return new_value
 
-                elif self._pv_manager.is_server_message(reason):
+                elif is_pv_name_this_field(SERVER_MESSAGE, reason):
                     return STATUS_MANAGER.message
-                elif self._pv_manager.is_error_log(reason):
+                elif is_pv_name_this_field(SERVER_ERROR_LOG, reason):
                     return STATUS_MANAGER.error_log
-                elif self._pv_manager.is_sample_length(reason):
+                elif is_pv_name_this_field(SAMPLE_LENGTH, reason):
                     return self._footprint_manager.get_sample_length()
                 elif self._pv_manager.is_alarm_status(reason):
                     return self.getParamDB(self._pv_manager.strip_fields_from_pv(reason)).alarm
@@ -145,9 +145,9 @@ class ReflectometryDriver(Driver):
         try:
             if self._pv_manager.is_param(reason):
                 value_accepted = self._driver_help.param_write(reason, value)
-            elif self._pv_manager.is_beamline_move(reason):
+            elif is_pv_name_this_field(BEAMLINE_MOVE, reason):
                 self._beamline.move = 1
-            elif self._pv_manager.is_reapply_mode_inits(reason):
+            elif is_pv_name_this_field(REAPPLY_MODE_INITS, reason):
                 self._beamline.reinit_mode_on_move = value
             elif self._pv_manager.is_beamline_mode(reason):
                 try:
@@ -158,7 +158,7 @@ class ReflectometryDriver(Driver):
                     STATUS_MANAGER.update_error_log("Invalid value entered for mode. (Possible modes: {})".format(
                         ",".join(self._beamline.mode_names)))
                     value_accepted = False
-            elif self._pv_manager.is_sample_length(reason):
+            elif is_pv_name_this_field(SAMPLE_LENGTH, reason):
                 self._footprint_manager.set_sample_length(value)
             else:
                 STATUS_MANAGER.update_error_log("Error: PV is read only")

--- a/ReflectometryServer/ChannelAccess/reflectometry_driver.py
+++ b/ReflectometryServer/ChannelAccess/reflectometry_driver.py
@@ -103,6 +103,9 @@ class ReflectometryDriver(Driver):
                 elif self._pv_manager.is_beamline_move(reason):
                     return self._beamline.move
 
+                elif self._pv_manager.is_reapply_mode_inits(reason):
+                    return self._beamline.reinit_mode_on_move
+
                 elif self._pv_manager.is_server_status(reason):
                     beamline_status_enums = self._pv_manager.PVDB[SERVER_STATUS]["enums"]
                     new_value = beamline_status_enums.index(STATUS_MANAGER.status.display_string)
@@ -144,6 +147,8 @@ class ReflectometryDriver(Driver):
                 value_accepted = self._driver_help.param_write(reason, value)
             elif self._pv_manager.is_beamline_move(reason):
                 self._beamline.move = 1
+            elif self._pv_manager.is_reapply_mode_inits(reason):
+                self._beamline.reinit_mode_on_move = value
             elif self._pv_manager.is_beamline_mode(reason):
                 try:
                     beamline_mode_enums = self._pv_manager.PVDB[BEAMLINE_MODE]["enums"]

--- a/ReflectometryServer/beamline.py
+++ b/ReflectometryServer/beamline.py
@@ -189,6 +189,9 @@ class Beamline:
         self._active_mode = None
         self._initialise_mode(modes)
 
+        # Say whether to reinitialise the paramter mode_inits on a move all
+        self.reinit_mode_on_move = False
+
         # initialise drivers (mode must be initialised first because of mode dependent engineering correction
         for driver in self._drivers:
             driver.set_observe_mode_change_on(self)
@@ -291,6 +294,8 @@ class Beamline:
             _: dummy can be anything
         """
         STATUS_MANAGER.clear_all()
+        if self.reinit_mode_on_move:
+            self._init_params_from_mode()
         self._move_for_all_beamline_parameters()
 
     def __getitem__(self, item):

--- a/ReflectometryServer/test_modules/data_mother.py
+++ b/ReflectometryServer/test_modules/data_mother.py
@@ -18,7 +18,7 @@ from ReflectometryServer.components import Component, TiltingComponent, ThetaCom
     BenchComponent, BenchSetup
 from ReflectometryServer.geometry import PositionAndAngle
 from ReflectometryServer.ioc_driver import IocDriver
-from ReflectometryServer.parameters import BeamlineParameter, AxisParameter, DirectParameter, \
+from ReflectometryServer.parameters import BeamlineParameter, AxisParameter, \
     SlitGapParameter, InBeamParameter
 import numpy as np
 
@@ -102,7 +102,7 @@ class DataMother:
 
         # s1
         s1 = add_component(Component("s1_comp", PositionAndAngle(0.0, 1 * spacing, 90)))
-        add_parameter(AxisParameter("s1", s1, ChangeAxis.POSITION), modes = [nr])
+        add_parameter(AxisParameter("s1", s1, ChangeAxis.POSITION), modes=[nr])
         s1_axis = create_mock_axis("MOT:MTR0101", 0, 1)
         add_driver(IocDriver(s1, ChangeAxis.POSITION, s1_axis))
 
@@ -119,17 +119,17 @@ class DataMother:
         # detector
         detector = add_component(TiltingComponent("Detector_comp", PositionAndAngle(0.0, 4 * spacing, 90)))
         theta.add_angle_to(detector)
-        add_parameter(AxisParameter("det", detector, ChangeAxis.POSITION), modes = [nr, disabled])
-        add_parameter(AxisParameter("det_angle", detector, ChangeAxis.ANGLE), modes = [nr, disabled])
+        add_parameter(AxisParameter("det", detector, ChangeAxis.POSITION), modes=[nr, disabled])
+        add_parameter(AxisParameter("det_angle", detector, ChangeAxis.ANGLE), modes=[nr, disabled])
         det_axis = create_mock_axis("MOT:MTR0104", 0, 1)
         add_driver(IocDriver(detector, ChangeAxis.POSITION, det_axis))
         det_angle_axis = create_mock_axis("MOT:MTR0105", 0, 1)
         add_driver(IocDriver(detector, ChangeAxis.ANGLE, det_angle_axis))
 
         axes = {"s1_axis": s1_axis,
-                  "s3_axis": s3_axis,
-                  "det_axis": det_axis,
-                  "det_angle_axis": det_angle_axis}
+                "s3_axis": s3_axis,
+                "det_axis": det_axis,
+                "det_angle_axis": det_angle_axis}
 
         add_beam_start(PositionAndAngle(0.0, 0.0, 0.0))
         bl = get_configured_beamline()
@@ -329,6 +329,16 @@ class DataMother:
         theta_comp.add_angle_to(detector_comp)
         get_configured_beamline()
         return det_in, theta
+
+    @staticmethod
+    def beamline_with_one_mode_init_param_in_mode_and_at_off_init(init_sm_angle, off_init, param_name):
+        super_mirror = ReflectingComponent("super mirror", PositionAndAngle(z=10, y=0, angle=90))
+        smangle = AxisParameter(param_name, super_mirror, ChangeAxis.ANGLE)
+        beamline_mode = BeamlineMode("mode name", [smangle.name], {smangle.name: init_sm_angle})
+        beamline = Beamline([super_mirror], [smangle], [], [beamline_mode])
+        beamline.active_mode = beamline_mode.name
+        smangle.sp = off_init
+        return Beamline([super_mirror], [smangle], [], [beamline_mode])
 
 
 def create_mock_axis(name, init_position, max_velocity, backlash_distance=0, backlash_velocity=1, direction="Pos"):

--- a/ReflectometryServer/test_modules/test_beamline_parameter.py
+++ b/ReflectometryServer/test_modules/test_beamline_parameter.py
@@ -423,7 +423,7 @@ class TestBeamlineOnMove(unittest.TestCase):
         beamline_parameters[0].move = 1
         moves = [beamline_parameter.move_component_count for beamline_parameter in beamline_parameters]
 
-        assert_that(moves, contains(1, 1, 1), "beamline parameter move counts")
+        assert_that(moves, contains_exactly(1, 1, 1), "beamline parameter move counts")
 
     def test_GIVEN_three_beamline_parameters_WHEN_move_2nd_THEN_2nd_and_3rd_move(self):
         beamline_parameters, _ = DataMother.beamline_with_3_empty_parameters()
@@ -431,7 +431,7 @@ class TestBeamlineOnMove(unittest.TestCase):
         beamline_parameters[1].move = 1
         moves = [beamline_parameter.move_component_count for beamline_parameter in beamline_parameters]
 
-        assert_that(moves, contains(0, 1, 1), "beamline parameter move counts")
+        assert_that(moves, contains_exactly(0, 1, 1), "beamline parameter move counts")
 
     def test_GIVEN_three_beamline_parameters_WHEN_move_3rd_THEN_3rd_moves(self):
         beamline_parameters, _ = DataMother.beamline_with_3_empty_parameters()
@@ -439,7 +439,7 @@ class TestBeamlineOnMove(unittest.TestCase):
         beamline_parameters[2].move = 1
         moves = [beamline_parameter.move_component_count for beamline_parameter in beamline_parameters]
 
-        assert_that(moves, contains(0, 0, 1), "beamline parameter move counts")
+        assert_that(moves, contains_exactly(0, 0, 1), "beamline parameter move counts")
 
     def test_GIVEN_three_beamline_parameters_and_1_and_3_in_mode_WHEN_move_1st_THEN_parameters_in_the_mode_move(self):
         beamline_parameters, beamline = DataMother.beamline_with_3_empty_parameters()
@@ -448,7 +448,7 @@ class TestBeamlineOnMove(unittest.TestCase):
         beamline_parameters[0].move = 1
         moves = [beamline_parameter.move_component_count for beamline_parameter in beamline_parameters]
 
-        assert_that(moves, contains(1, 0, 1), "beamline parameter move counts")
+        assert_that(moves, contains_exactly(1, 0, 1), "beamline parameter move counts")
 
     def test_GIVEN_three_beamline_parameters_and_3_in_mode_WHEN_move_1st_THEN_only_2nd_parameter_moved(self):
         beamline_parameters, beamline = DataMother.beamline_with_3_empty_parameters()
@@ -457,7 +457,7 @@ class TestBeamlineOnMove(unittest.TestCase):
         beamline_parameters[0].move = 1
         moves = [beamline_parameter.move_component_count for beamline_parameter in beamline_parameters]
 
-        assert_that(moves, contains(1, 0, 0), "beamline parameter move counts")
+        assert_that(moves, contains_exactly(1, 0, 0), "beamline parameter move counts")
 
     def test_GIVEN_three_beamline_parameters_in_mode_WHEN_1st_changed_and_move_beamline_THEN_all_move(self):
         beamline_parameters, beamline = DataMother.beamline_with_3_empty_parameters()
@@ -466,7 +466,7 @@ class TestBeamlineOnMove(unittest.TestCase):
         beamline.move = 1
         moves = [beamline_parameter.move_component_count for beamline_parameter in beamline_parameters]
 
-        assert_that(moves, contains(1, 1, 1), "beamline parameter move counts")
+        assert_that(moves, contains_exactly(1, 1, 1), "beamline parameter move counts")
 
     @parameterized.expand([("s1", 12.132, "theta", 4.012), ("s3", 1.123, "theta", 2.342)])
     def test_GIVEN_parameter_with_new_sp_WHEN_theta_moved_independently_THEN_parameter_unchanged(self, param, param_sp, theta, theta_sp):
@@ -498,6 +498,29 @@ class TestBeamlineOnMove(unittest.TestCase):
 
         assert_that(param_final_position, is_(close_to(param_init_position, delta=1e-6)))
 
+    def test_GIVEN_parameter_with_mode_init_and_beamline_set_not_to_reinit_on_move_WHEN_in_mode_but_not_at_init_THEN_move_all_param_does_not_reinit(self):
+        sm_angle = 0.0
+        init_sm_angle = 45.0
+        param_name = "smangle"
+        beamline = DataMother.beamline_with_one_mode_init_param_in_mode_and_at_off_init(init_sm_angle, sm_angle, param_name)
+
+        beamline.move = 1
+
+        assert_that(beamline.parameter(param_name).sp, is_(sm_angle))
+        assert_that(beamline.parameter(param_name).sp_changed, is_(False))
+
+    def test_GIVEN_parameter_with_mode_init_and_beamline_set_to_reinit_on_move_WHEN_in_mode_but_not_at_init_THEN_move_all_param_does_reinit(self):
+        sm_angle = 0.0
+        init_sm_angle = 45.0
+        param_name = "smangle"
+        beamline = DataMother.beamline_with_one_mode_init_param_in_mode_and_at_off_init(init_sm_angle, sm_angle, param_name)
+
+        beamline.reinit_mode_on_move = True
+        beamline.move = 1
+
+        assert_that(beamline.parameter(param_name).sp, is_(init_sm_angle))
+        assert_that(beamline.parameter(param_name).sp_changed, is_(False))
+
 
 class TestBeamlineParameterReadback(unittest.TestCase):
 
@@ -526,7 +549,7 @@ class TestBeamlineParameterReadback(unittest.TestCase):
         sample.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(CorrectedReadbackUpdate(displacement, None, None))
 
         listener.assert_called_with(ParameterReadbackUpdate(displacement - beam_height, None, None))
-        assert_that(listener.call_count, is_(2))  #  once for beam path and once for physcial move
+        assert_that(listener.call_count, is_(2))  # once for beam path and once for physcial move
 
     def test_GIVEN_reflection_angle_WHEN_set_readback_on_component_THEN_call_back_triggered_on_component_change(self):
 


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/5781

To test:
* Confirm new unit tests run
* Start the reflectometry server with a parameter that has mode inits
* Move the parameter away from it's init and press move all, confirm it doesn't move
* Do the same with the apply inits checkbox set and confirm it does move