### PR TITLE
Ticket 5896: INTER long axis

### DIFF
--- a/ReflectometryServer/axis.py
+++ b/ReflectometryServer/axis.py
@@ -356,6 +356,16 @@ class BeamPathCalcModificationAxis(DirectCalcAxis):
         super().on_set_relative_to_beam(position)
         self.update_calc_function(position)
 
+    def init_displacement_from_motor(self, motor_position):
+        """
+        Sets the displacement read from the motor axis on startup and informs the beam path calc of this.
+
+        Args:
+            motor_position (float): The motor position
+        """
+        self.update_calc_function(motor_position)
+        super().init_displacement_from_motor(motor_position)
+
 
 class BeamPathCalcAxis(ComponentAxis):
     """

--- a/ReflectometryServer/axis.py
+++ b/ReflectometryServer/axis.py
@@ -319,9 +319,47 @@ class DirectCalcAxis(ComponentAxis):
         self.trigger_listeners(InitUpdate())  # Tell Parameter layer and Theta
 
 
+class BeamPathCalcModificationAxis(DirectCalcAxis):
+    """
+    Axes where the relative and mantid coordinates are directly connected but changing them may affect the beam path
+    calc for other axes. E.g. used for the long axis
+
+    This is basically a thin layer that calls the function on the direct calc axis but informs the beam path calc of
+    what it's doing. This object is initialised with the functions to call.
+    """
+    def __init__(self, axis, update_calc_function):
+        """
+        Initialiser.
+        Args:
+            axis: the axis this object is of
+            update_calc_function: function to call when the axis position changes
+                                 (will give the new position as an argument)
+        """
+        super().__init__(axis)
+        self.update_calc_function = update_calc_function
+
+    def _on_set_displacement(self, displacement):
+        """
+        Update the driver axis as usual then inform the beam path calc of the new value.
+        Args:
+            displacement (float): pv update for this axis
+        """
+        super()._on_set_displacement(displacement)
+        self.update_calc_function(displacement)
+
+    def on_set_relative_to_beam(self, position):
+        """
+        Update the driver axis as usual then inform the beam path calc of the new value.
+        Args:
+            position (float): pv update for this axis
+        """
+        super().on_set_relative_to_beam(position)
+        self.update_calc_function(position)
+
+
 class BeamPathCalcAxis(ComponentAxis):
     """
-    Axes for a component for the beam path calc. Used to setup for either the position and angle axis.
+    Axes where the value is derived from a beam path calc. Used to setup for either the position and angle axis.
 
     This is basically a thin layer that calls the function on the axis and then delegates to the beam path calc. This
     object is initialised with the functions to call.

--- a/ReflectometryServer/axis.py
+++ b/ReflectometryServer/axis.py
@@ -36,7 +36,7 @@ class AddOutOfBeamPositionEvent:
 @dataclass()
 class AxisChangedUpdate:
     """
-    Event when changed if updated
+    Event when the user has changed the parameter but not yet been moved to (e.g. the yellow background)
     """
     is_changed_update: bool  # True if there is an unapplied updated; False otherwise
 

--- a/ReflectometryServer/beam_path_calc.py
+++ b/ReflectometryServer/beam_path_calc.py
@@ -8,7 +8,8 @@ from math import degrees, atan2, isnan
 from typing import Dict, List, Tuple
 
 from ReflectometryServer.axis import PhysicalMoveUpdate, AxisChangingUpdate, InitUpdate, ComponentAxis, \
-    BeamPathCalcAxis, AddOutOfBeamPositionEvent, AxisChangedUpdate, SetRelativeToBeamUpdate, DirectCalcAxis
+    BeamPathCalcAxis, AddOutOfBeamPositionEvent, AxisChangedUpdate, SetRelativeToBeamUpdate, \
+    BeamPathCalcModificationAxis
 from ReflectometryServer.geometry import PositionAndAngle, ChangeAxis, Position
 import logging
 
@@ -130,11 +131,10 @@ class TrackingBeamPathCalc:
                                                   self._get_displacement,
                                                   self._displacement_update,
                                                   self._init_displacement_from_motor),
-            ChangeAxis.LONG_AXIS: DirectCalcAxis(ChangeAxis.LONG_AXIS)
-        }
 
-        self.axis[ChangeAxis.LONG_AXIS].add_listener(PhysicalMoveUpdate, self._on_long_axis_change)
-        self.axis[ChangeAxis.LONG_AXIS].add_listener(SetRelativeToBeamUpdate, self._on_long_axis_change)
+            ChangeAxis.LONG_AXIS: BeamPathCalcModificationAxis(ChangeAxis.LONG_AXIS,
+                                                               self._on_long_axis_change)
+        }
 
     def _init_displacement_from_motor(self, value):
         """
@@ -187,12 +187,14 @@ class TrackingBeamPathCalc:
     def _on_in_beam_status_update(self, _):
         self.trigger_listeners(BeamPathUpdate(self))
 
-    def _on_long_axis_change(self, _):
+    def _on_long_axis_change(self, displacement):
         """
         Changes the location of the movement strategy when the long axis (the axis along the beam) changes.
         For now assume that the movement is entirely perpendicular to the natural beam.
+        Args:
+            displacement: the change in the long axis
         """
-        offset_position = Position(0, self.axis[ChangeAxis.LONG_AXIS].get_displacement())
+        offset_position = Position(0, displacement)
         self._movement_strategy.offset_position_at_zero(offset_position)
         self.trigger_listeners(BeamPathUpdate(self))
 

--- a/ReflectometryServer/beam_path_calc.py
+++ b/ReflectometryServer/beam_path_calc.py
@@ -8,7 +8,7 @@ from math import degrees, atan2, isnan
 from typing import Dict, List, Tuple
 
 from ReflectometryServer.axis import PhysicalMoveUpdate, AxisChangingUpdate, InitUpdate, ComponentAxis, \
-    BeamPathCalcAxis, AddOutOfBeamPositionEvent, AxisChangedUpdate, DirectCalcAxis
+    BeamPathCalcAxis, AddOutOfBeamPositionEvent, AxisChangedUpdate, SetRelativeToBeamUpdate, DirectCalcAxis
 from ReflectometryServer.geometry import PositionAndAngle, ChangeAxis, Position
 import logging
 
@@ -134,7 +134,7 @@ class TrackingBeamPathCalc:
         }
 
         self.axis[ChangeAxis.LONG_AXIS].add_listener(PhysicalMoveUpdate, self._on_long_axis_change)
-        self.axis[ChangeAxis.LONG_AXIS].add_listener(AxisChangedUpdate, self._on_long_axis_change)
+        self.axis[ChangeAxis.LONG_AXIS].add_listener(SetRelativeToBeamUpdate, self._on_long_axis_change)
 
     def _init_displacement_from_motor(self, value):
         """
@@ -461,7 +461,7 @@ class BeamPathCalcThetaRBV(_BeamPathCalcWithAngle):
     A reflecting beam path calculator which has a read only angle based on the angle to a list of beam path
     calculations. This is used for example for Theta where the angle is the angle to the next enabled component.
     """
-    _angle_to: List[Tuple[TrackingBeamPathCalc, TrackingBeamPathCalc, ChangeAxis]]
+    _angle_to: List[Tuple[TrackingBeamPathCalc, TrackingBeamPathCalc, List[ChangeAxis]]]
 
     def __init__(self, name, movement_strategy, theta_setpoint_beam_path_calc):
         """
@@ -483,7 +483,7 @@ class BeamPathCalcThetaRBV(_BeamPathCalcWithAngle):
         self.theta_setpoint_beam_path_calc = theta_setpoint_beam_path_calc
         self._add_pre_trigger_function(BeamPathUpdate, self._set_incoming_beam_at_next_angled_to_component)
 
-    def add_angle_to(self, readback_beam_path_calc, setpoint_beam_path_calc, axis):
+    def add_angle_to(self, readback_beam_path_calc, setpoint_beam_path_calc, axes):
         """
         Add angle to these beam path calcs and setpoints on this axis on which to base the angle and setpoint on which
             the offset is taken. This add it to the end of the list.
@@ -491,31 +491,36 @@ class BeamPathCalcThetaRBV(_BeamPathCalcWithAngle):
             readback_beam_path_calc (ReflectometryServer.beam_path_calc.TrackingBeamPathCalc): readback calc
             setpoint_beam_path_calc (ReflectometryServer.beam_path_calc.TrackingBeamPathCalc): set point calc needed for
                 the offset from the beam that should be used
-            axis (ChangeAxis.POSITION|ChangeAxis.ANGLE): axis on which to base the angle to
+            axes (List[ChangeAxis]): axes on which to base the angle to
         """
-        self._angle_to.append((readback_beam_path_calc, setpoint_beam_path_calc, axis))
+        self._angle_to.append((readback_beam_path_calc, setpoint_beam_path_calc, axes))
+
         # add to the physical change for the rbv so that we don't get an infinite loop
-        readback_beam_path_calc.axis[axis].add_listener(PhysicalMoveUpdate, self._angle_update)
+        # and add to beamline change of set point because no loop is created from the setpoint action
+        for axis in axes:
+            readback_beam_path_calc.axis[axis].add_listener(PhysicalMoveUpdate, self._angle_update)
+            readback_beam_path_calc.axis[axis].add_listener(AxisChangingUpdate, self._on_is_changing_change)
         readback_beam_path_calc.in_beam_manager.add_listener(PhysicalMoveUpdate, self._angle_update)
-        # add to beamline change of set point because no loop is created from the setpoint action
+
         setpoint_beam_path_calc.add_listener(BeamPathUpdate, self._angle_update)
-        readback_beam_path_calc.axis[axis].add_listener(AxisChangingUpdate, self._on_is_changing_change)
         readback_beam_path_calc.in_beam_manager.add_listener(AxisChangingUpdate, self._on_is_changing_change)
 
     def _on_is_changing_change(self, _):
         """
-        Updates the changing state of this component. Theta is changing if the first in beam component is changing or
-        if there are no in beam components and one out of beam component is changing
+        Updates the changing state of this component. Theta is changing if an axis on the first in beam component is
+        changing or if there are no in beam components and one out of beam component is changing
 
         Args:
             _ (AxisChangingUpdate): The update event
         """
         theta_is_changing = False
-        for readback_beam_path_calc, setpoint_beam_path_calc, axis in self._angle_to:
-            is_changing = readback_beam_path_calc.axis[axis].is_changing
-            theta_is_changing = theta_is_changing or is_changing
+        for readback_beam_path_calc, _, axes in self._angle_to:
+            axis_is_changing = False
+            for axis in axes:
+                axis_is_changing |= readback_beam_path_calc.axis[axis].is_changing
+            theta_is_changing = theta_is_changing or axis_is_changing
             if readback_beam_path_calc.is_in_beam:
-                theta_is_changing = is_changing
+                theta_is_changing = axis_is_changing
                 break
 
         self.axis[ChangeAxis.ANGLE].is_changing = theta_is_changing
@@ -539,9 +544,9 @@ class BeamPathCalcThetaRBV(_BeamPathCalcWithAngle):
         for readback_beam_path_calc, _, _ in self._angle_to:
             readback_beam_path_calc.substitute_incoming_beam_for_displacement = None
 
-        for readback_beam_path_calc, set_point_beam_path_calc, axis in self._angle_to:
+        for readback_beam_path_calc, set_point_beam_path_calc, axes in self._angle_to:
             if readback_beam_path_calc.is_in_beam:
-                if axis == ChangeAxis.POSITION:
+                if ChangeAxis.POSITION in axes:
                     other_pos = readback_beam_path_calc.position_in_mantid_coordinates()
                     set_point_offset = set_point_beam_path_calc.get_distance_relative_to_beam_in_mantid_coordinates()
                     this_pos = self._movement_strategy.calculate_interception(incoming_beam)
@@ -554,21 +559,26 @@ class BeamPathCalcThetaRBV(_BeamPathCalcWithAngle):
                     # x + incoming_beam.angle: angle of sample in room coordinate
 
                     angle_of_outgoing_beam = degrees(atan2(opp, adj))
-                elif axis == ChangeAxis.ANGLE:
+                elif ChangeAxis.ANGLE in axes:
                     # rbv should not include setpoint offset angle
                     other_angle = readback_beam_path_calc.axis[ChangeAxis.ANGLE].get_displacement()
                     other_setpoint_offset = set_point_beam_path_calc.axis[ChangeAxis.ANGLE].get_relative_to_beam()
                     angle_of_outgoing_beam = other_angle - other_setpoint_offset
                 else:
-                    raise RuntimeError("Theta can not depend on the {} axis".format(axis))
+                    raise RuntimeError("Theta can not depend on the {} axes".format(axes))
 
                 angle = (angle_of_outgoing_beam - incoming_beam.angle) / 2.0 + incoming_beam.angle
                 # set the beam path for the selected component
                 readback_beam_path_calc.substitute_incoming_beam_for_displacement = \
                     self.theta_setpoint_beam_path_calc.get_outgoing_beam()
-                # set alarms from component setting the angle
-                alarm_severity, alarm_status = readback_beam_path_calc.axis[axis].alarm
-                self.axis[ChangeAxis.ANGLE].set_alarm(alarm_severity, alarm_status)
+
+                # set the most major alarm from component setting the angle
+                severity, status = AlarmSeverity.No, AlarmStatus.No
+                for axis in axes:
+                    axis_severity, axis_status = readback_beam_path_calc.axis[axis].alarm
+                    if axis_severity > severity:
+                        severity, status = axis_severity, axis_status
+                self.axis[ChangeAxis.ANGLE].set_alarm(severity, status)
 
                 break
         else:

--- a/ReflectometryServer/components.py
+++ b/ReflectometryServer/components.py
@@ -157,9 +157,9 @@ class ThetaComponent(ReflectingComponent):
             component (ReflectometryServer.components.Component): component that defines theta
 
         """
-        self._beam_path_set_point.add_angle_to(component.beam_path_set_point, ChangeAxis.POSITION)
-        self._beam_path_rbv.add_angle_to(component.beam_path_rbv, component.beam_path_set_point,
-                                         [ChangeAxis.POSITION, ChangeAxis.LONG_AXIS])
+        axes = [ChangeAxis.POSITION, ChangeAxis.LONG_AXIS]
+        self._beam_path_set_point.add_angle_to(component.beam_path_set_point, axes)
+        self._beam_path_rbv.add_angle_to(component.beam_path_rbv, component.beam_path_set_point, axes)
 
     def add_angle_of(self, component):
         """
@@ -170,7 +170,7 @@ class ThetaComponent(ReflectingComponent):
             component (ReflectometryServer.components.Component): component that defines theta
 
         """
-        self._beam_path_set_point.add_angle_to(component.beam_path_set_point, ChangeAxis.ANGLE)
+        self._beam_path_set_point.add_angle_to(component.beam_path_set_point, [ChangeAxis.ANGLE])
         self._beam_path_rbv.add_angle_to(component.beam_path_rbv, component.beam_path_set_point, [ChangeAxis.ANGLE])
 
     def _init_beam_path_calcs(self, setup):

--- a/ReflectometryServer/components.py
+++ b/ReflectometryServer/components.py
@@ -158,7 +158,8 @@ class ThetaComponent(ReflectingComponent):
 
         """
         self._beam_path_set_point.add_angle_to(component.beam_path_set_point, ChangeAxis.POSITION)
-        self._beam_path_rbv.add_angle_to(component.beam_path_rbv, component.beam_path_set_point, ChangeAxis.POSITION)
+        self._beam_path_rbv.add_angle_to(component.beam_path_rbv, component.beam_path_set_point,
+                                         [ChangeAxis.POSITION, ChangeAxis.LONG_AXIS])
 
     def add_angle_of(self, component):
         """
@@ -170,7 +171,7 @@ class ThetaComponent(ReflectingComponent):
 
         """
         self._beam_path_set_point.add_angle_to(component.beam_path_set_point, ChangeAxis.ANGLE)
-        self._beam_path_rbv.add_angle_to(component.beam_path_rbv, component.beam_path_set_point, ChangeAxis.ANGLE)
+        self._beam_path_rbv.add_angle_to(component.beam_path_rbv, component.beam_path_set_point, [ChangeAxis.ANGLE])
 
     def _init_beam_path_calcs(self, setup):
         linear_movement_calc = LinearMovementCalc(setup)

--- a/ReflectometryServer/geometry.py
+++ b/ReflectometryServer/geometry.py
@@ -30,8 +30,8 @@ class PositionAndAngle(Position):
         """
 
         Args:
-            z: z position in room co-ordinates
             y: y position in room co-ordinates
+            z: z position in room co-ordinates
             angle: clockwise angle measured from the horizon (90 to -90 with 0 pointing away from the source)
         """
         super(PositionAndAngle, self).__init__(y, z)
@@ -103,6 +103,8 @@ class ChangeAxis(Enum):
     PSI = 5         # angle like roll
     HEIGHT = 6      # height axis perpendicular to beam and the floor
     TRANS = 7       # translation axis perpendicular to beam and parallel to the floor
-    JACK_FRONT = 8  # on the bench the jack at the front of the table
-    JACK_REAR = 9   # on the bench the jack at the rear of the table
-    SLIDE = 10      # on the bench the horizontal slide
+    LONG_AXIS = 8   # axis along the beam
+    JACK_FRONT = 9  # on the bench the jack at the front of the table
+    JACK_REAR = 10  # on the bench the jack at the rear of the table
+    SLIDE = 11      # on the bench the horizontal slide
+

--- a/ReflectometryServer/ioc_driver.py
+++ b/ReflectometryServer/ioc_driver.py
@@ -185,24 +185,18 @@ class IocDriver:
 
         if self._out_of_beam_lookup is not None:
             beam_interception = beam_path_setpoint.calculate_beam_interception()
-<<<<<<< HEAD
-            distance_relative_to_beam = corrected_axis_setpoint - beam_path_setpoint.axis[self.component_axis].get_displacement_for(0)
-            in_beam_status = self._get_in_beam_status(beam_interception, self._motor_axis.sp, distance_relative_to_beam)
-            beam_path_setpoint.axis[self.component_axis].is_in_beam = in_beam_status
-=======
             distance_relative_to_beam = \
-                corrected_axis_setpoint - beam_path_setpoint.axis[self._component_axis].get_displacement_for(0)
+                corrected_axis_setpoint - beam_path_setpoint.axis[self.component_axis].get_displacement_for(0)
 
             max_sequence_count = self._out_of_beam_lookup.get_max_sequence_count()
             in_beam_status, is_at_sequence_end = self._get_in_beam_status(beam_interception, self._motor_axis.sp,
                                                                           distance_relative_to_beam, max_sequence_count)
-            beam_path_setpoint.axis[self._component_axis].is_in_beam = in_beam_status
+            beam_path_setpoint.axis[self.component_axis].is_in_beam = in_beam_status
             if in_beam_status:
-                beam_path_setpoint.axis[self._component_axis].init_parking_index(None)
+                beam_path_setpoint.axis[self.component_axis].init_parking_index(None)
             else:
-                beam_path_setpoint.axis[self._component_axis].init_parking_index(max_sequence_count)
+                beam_path_setpoint.axis[self.component_axis].init_parking_index(max_sequence_count)
 
->>>>>>> master
             # if the motor_axis is out of the beam then no correction needs adding to setpoint
             if not in_beam_status:
                 corrected_axis_setpoint = self._motor_axis.sp
@@ -376,30 +370,19 @@ class IocDriver:
             STATUS_MANAGER.update_active_problems(
                 ProblemInfo("No out of beam position defined for motor_axis", self.name, Severity.MINOR_ALARM))
 
-<<<<<<< HEAD
-        if self.component.beam_path_set_point.is_in_beam or self._out_of_beam_lookup is None:
-            displacement = self.component.beam_path_set_point.axis[self.component_axis].get_displacement()
-        else:
-            beam_interception = self.component.beam_path_set_point.calculate_beam_interception()
-=======
-        parking_index = self._component.beam_path_set_point.in_beam_manager.parking_index
+        parking_index = self.component.beam_path_set_point.in_beam_manager.parking_index
         if parking_index is None or self._out_of_beam_lookup is None:
-            displacement = self._component.beam_path_set_point.axis[self._component_axis].get_displacement()
-            is_to_from_park = not self._component.beam_path_rbv.axis[self._component_axis].is_in_beam
+            displacement = self.component.beam_path_set_point.axis[self.component_axis].get_displacement()
+            is_to_from_park = not self.component.beam_path_rbv.axis[self.component_axis].is_in_beam
         else:
             is_to_from_park = True
-            beam_interception = self._component.beam_path_set_point.calculate_beam_interception()
->>>>>>> master
+            beam_interception = self.component.beam_path_set_point.calculate_beam_interception()
+
             out_of_beam_position = self._out_of_beam_lookup.get_position_for_intercept(beam_interception)
 
             if out_of_beam_position.is_offset:
-<<<<<<< HEAD
                 displacement = self.component.beam_path_set_point.axis[self.component_axis].\
-                    get_displacement_for(out_of_beam_position.position)
-=======
-                displacement = self._component.beam_path_set_point.axis[self._component_axis].\
                     get_displacement_for(out_of_beam_position.get_sequence_position(parking_index))
->>>>>>> master
             else:
                 displacement = out_of_beam_position.get_sequence_position(parking_index)
             if displacement is None and for_correction:
@@ -441,23 +424,16 @@ class IocDriver:
         self.component.beam_path_rbv.axis[self.component_axis].set_displacement(update)
 
         if self._out_of_beam_lookup is not None:
-<<<<<<< HEAD
             beam_interception = self.component.beam_path_rbv.calculate_beam_interception()
             distance_relative_to_beam = self.component.beam_path_rbv.axis[self.component_axis].get_relative_to_beam()
-            self.component.beam_path_rbv.axis[self.component_axis].is_in_beam = self._get_in_beam_status(
-                beam_interception, update.value, distance_relative_to_beam)
-=======
-            beam_interception = self._component.beam_path_rbv.calculate_beam_interception()
-            distance_relative_to_beam = self._component.beam_path_rbv.axis[self._component_axis].get_relative_to_beam()
-            parking_index = self._component.beam_path_set_point.in_beam_manager.parking_index
+            parking_index = self.component.beam_path_set_point.in_beam_manager.parking_index
 
             in_beam_status, is_at_sequence_position = self._get_in_beam_status(
                 beam_interception, update.value, distance_relative_to_beam, parking_index)
 
-            self._component.beam_path_rbv.axis[self._component_axis].is_in_beam = in_beam_status
+            self.component.beam_path_rbv.axis[self.component_axis].is_in_beam = in_beam_status
             if is_at_sequence_position:
-                self._component.beam_path_rbv.axis[self._component_axis].parking_index = parking_index
->>>>>>> master
+                self.component.beam_path_rbv.axis[self.component_axis].parking_index = parking_index
 
     def _get_in_beam_status(self, beam_intersect, value, distance_relative_to_beam, parking_index):
         if self._out_of_beam_lookup is not None:

--- a/ReflectometryServer/ioc_driver.py
+++ b/ReflectometryServer/ioc_driver.py
@@ -64,8 +64,8 @@ class IocDriver:
                 sent to the pv. None for no correction
             pv_wrapper_for_parameter: change the pv wrapper based on the value of a parameter
         """
-        self._component = component
-        self._component_axis = component_axis
+        self.component = component
+        self.component_axis = component_axis
         self._default_motor_axis = motor_axis
         self._motor_axis = None
         self._set_motor_axis(motor_axis, False)
@@ -78,8 +78,8 @@ class IocDriver:
         else:
             try:
                 self._out_of_beam_lookup = OutOfBeamLookup(out_of_beam_positions)
-                self._component.beam_path_rbv.axis[component_axis].has_out_of_beam_position = True
-                self._component.beam_path_set_point.axis[component_axis].has_out_of_beam_position = True
+                self.component.beam_path_rbv.axis[component_axis].has_out_of_beam_position = True
+                self.component.beam_path_set_point.axis[component_axis].has_out_of_beam_position = True
             except ValueError as e:
                 STATUS_MANAGER.update_error_log(str(e))
                 STATUS_MANAGER.update_active_problems(
@@ -98,7 +98,7 @@ class IocDriver:
         self._sp_cache = None
         self._rbv_cache = self._engineering_correction.from_axis(self._motor_axis.rbv, self._get_component_sp())
 
-        self._component.beam_path_rbv.axis[component_axis].add_listener(DefineValueAsEvent, self._on_define_value_as)
+        self.component.beam_path_rbv.axis[component_axis].add_listener(DefineValueAsEvent, self._on_define_value_as)
 
     def _set_motor_axis(self, pv_wrapper: PVWrapper, trigger_update: bool) -> None:
         """
@@ -151,12 +151,12 @@ class IocDriver:
         Args:
             new_correction_value (CorrectionUpdate): the new correction value
         """
-        description = "{} on {} for {}".format(new_correction_value.description, self.name, self._component.name)
+        description = "{} on {} for {}".format(new_correction_value.description, self.name, self.component.name)
         self.trigger_listeners(CorrectionUpdate(new_correction_value.correction, description))
 
     def __repr__(self):
         return "{} for axis pv {} and component {}".format(
-            self.__class__.__name__, self._motor_axis.name, self._component.name)
+            self.__class__.__name__, self._motor_axis.name, self.component.name)
 
     def initialise(self):
         """
@@ -172,8 +172,8 @@ class IocDriver:
         """
         Initialise the setpoint beam model in the component layer with an initial value read from the motor axis.
         """
-        beam_path_setpoint = self._component.beam_path_set_point
-        autosaved_value = beam_path_setpoint.axis[self._component_axis].autosaved_value
+        beam_path_setpoint = self.component.beam_path_set_point
+        autosaved_value = beam_path_setpoint.axis[self.component_axis].autosaved_value
         if autosaved_value is None:
             corrected_axis_setpoint = self._engineering_correction.init_from_axis(self._motor_axis.sp)
         else:
@@ -181,14 +181,14 @@ class IocDriver:
 
         if self._out_of_beam_lookup is not None:
             beam_interception = beam_path_setpoint.calculate_beam_interception()
-            distance_relative_to_beam = corrected_axis_setpoint - beam_path_setpoint.axis[self._component_axis].get_displacement_for(0)
+            distance_relative_to_beam = corrected_axis_setpoint - beam_path_setpoint.axis[self.component_axis].get_displacement_for(0)
             in_beam_status = self._get_in_beam_status(beam_interception, self._motor_axis.sp, distance_relative_to_beam)
-            beam_path_setpoint.axis[self._component_axis].is_in_beam = in_beam_status
+            beam_path_setpoint.axis[self.component_axis].is_in_beam = in_beam_status
             # if the motor_axis is out of the beam then no correction needs adding to setpoint
             if not in_beam_status:
                 corrected_axis_setpoint = self._motor_axis.sp
 
-        beam_path_setpoint.axis[self._component_axis].init_displacement_from_motor(corrected_axis_setpoint)
+        beam_path_setpoint.axis[self.component_axis].init_displacement_from_motor(corrected_axis_setpoint)
 
     def is_for_component(self, component):
         """
@@ -198,14 +198,14 @@ class IocDriver:
 
         Returns: True if this ioc driver uses the component; false otherwise
         """
-        return component is self._component
+        return component is self.component
 
     def _axis_will_move(self):
         """
         Returns: True if the axis set point has changed and it will move any distance
         """
         return not self.at_target_setpoint() and \
-            self._component.beam_path_set_point.axis[self._component_axis].is_changed
+            self.component.beam_path_set_point.axis[self.component_axis].is_changed
 
     def _backlash_duration(self):
         """
@@ -289,7 +289,7 @@ class IocDriver:
                 self._motor_axis.velocity = max(self._motor_axis.min_velocity, self._get_distance() / move_duration)
             self._motor_axis.sp = self._engineering_correction.to_axis(self._get_component_sp())
 
-        self._component.beam_path_set_point.axis[self._component_axis].is_changed = False
+        self.component.beam_path_set_point.axis[self.component_axis].is_changed = False
 
     def rbv_cache(self):
         """
@@ -315,21 +315,21 @@ class IocDriver:
         """
         Returns: position that the set point axis is set to
         """
-        if not self._component.beam_path_set_point.axis[self._component_axis].is_in_beam \
+        if not self.component.beam_path_set_point.axis[self.component_axis].is_in_beam \
                 and self._out_of_beam_lookup is None:
             STATUS_MANAGER.update_error_log(
                 "An axis for component {} is set to out of beam but there is no out of beam position defined "
-                "for the driver for the associated motor axis {}".format(self._component.name, self._motor_axis.name))
+                "for the driver for the associated motor axis {}".format(self.component.name, self._motor_axis.name))
             STATUS_MANAGER.update_active_problems(
                 ProblemInfo("No out of beam position defined for motor_axis", self.name, Severity.MINOR_ALARM))
 
-        if self._component.beam_path_set_point.is_in_beam or self._out_of_beam_lookup is None:
-            displacement = self._component.beam_path_set_point.axis[self._component_axis].get_displacement()
+        if self.component.beam_path_set_point.is_in_beam or self._out_of_beam_lookup is None:
+            displacement = self.component.beam_path_set_point.axis[self.component_axis].get_displacement()
         else:
-            beam_interception = self._component.beam_path_set_point.calculate_beam_interception()
+            beam_interception = self.component.beam_path_set_point.calculate_beam_interception()
             out_of_beam_position = self._out_of_beam_lookup.get_position_for_intercept(beam_interception)
             if out_of_beam_position.is_offset:
-                displacement = self._component.beam_path_set_point.axis[self._component_axis].\
+                displacement = self.component.beam_path_set_point.axis[self.component_axis].\
                     get_displacement_for(out_of_beam_position.position)
             else:
                 displacement = out_of_beam_position.position
@@ -367,12 +367,12 @@ class IocDriver:
         Signal that the motor readback value has changed to the middle component layer. Subclass must implement this
         method.
         """
-        self._component.beam_path_rbv.axis[self._component_axis].set_displacement(update)
+        self.component.beam_path_rbv.axis[self.component_axis].set_displacement(update)
 
         if self._out_of_beam_lookup is not None:
-            beam_interception = self._component.beam_path_rbv.calculate_beam_interception()
-            distance_relative_to_beam = self._component.beam_path_rbv.axis[self._component_axis].get_relative_to_beam()
-            self._component.beam_path_rbv.axis[self._component_axis].is_in_beam = self._get_in_beam_status(
+            beam_interception = self.component.beam_path_rbv.calculate_beam_interception()
+            distance_relative_to_beam = self.component.beam_path_rbv.axis[self.component_axis].get_relative_to_beam()
+            self.component.beam_path_rbv.axis[self.component_axis].is_in_beam = self._get_in_beam_status(
                 beam_interception, update.value, distance_relative_to_beam)
 
     def _get_in_beam_status(self, beam_intersect, value, distance_relative_to_beam):
@@ -398,7 +398,7 @@ class IocDriver:
         Args:
             update (ReflectometryServer.pv_wrapper.IsChangingUpdate): update of the is_moving status of the axis
         """
-        self._component.beam_path_rbv.axis[self._component_axis].is_changing = update.value
+        self.component.beam_path_rbv.axis[self.component_axis].is_changing = update.value
 
     def at_target_setpoint(self):
         """

--- a/ReflectometryServer/movement_strategy.py
+++ b/ReflectometryServer/movement_strategy.py
@@ -46,7 +46,7 @@ class LinearMovementCalc:
         z_b = beam.z
         angle_b = beam.angle
 
-        if z_b >= z_m:
+        if z_b > z_m:
             raise ValueError("Component ordered incorrectly, has LONG_AXIS moved too far?")
         if fabs(angle_b % 180.0 - angle_m % 180.0) <= ANGULAR_TOLERANCE:
             raise ValueError("No interception between beam and movement")

--- a/ReflectometryServer/movement_strategy.py
+++ b/ReflectometryServer/movement_strategy.py
@@ -25,7 +25,8 @@ class LinearMovementCalc:
             setup (ReflectometryServer.geometry.PositionAndAngle):
         """
         self._angle = setup.angle
-        self._position_at_zero = Position(setup.y, setup.z)
+        self._initial_position_at_zero = Position(setup.y, setup.z)
+        self._current_position_at_zero = self._initial_position_at_zero
         self._displacement = 0
 
     def calculate_interception(self, beam):
@@ -38,8 +39,8 @@ class LinearMovementCalc:
 
         """
         assert beam is not None
-        y_m = self._position_at_zero.y
-        z_m = self._position_at_zero.z
+        y_m = self._current_position_at_zero.y
+        z_m = self._current_position_at_zero.z
         angle_m = self._angle
         y_b = beam.y
         z_b = beam.z
@@ -48,13 +49,13 @@ class LinearMovementCalc:
         if fabs(angle_b % 180.0 - angle_m % 180.0) <= ANGULAR_TOLERANCE:
             raise ValueError("No interception between beam and movement")
         elif fabs(angle_b % 180.0) <= ANGULAR_TOLERANCE:
-            y, z = self._zero_angle(y_b, self._position_at_zero, self._angle)
+            y, z = self._zero_angle(y_b, self._current_position_at_zero, self._angle)
         elif fabs(angle_m % 180.0) <= ANGULAR_TOLERANCE:
             y, z = self._zero_angle(y_m, beam, beam.angle)
         elif fabs(angle_m % 180.0 - 90) <= ANGULAR_TOLERANCE or fabs(angle_m % 180.0 + 90) <= ANGULAR_TOLERANCE:
             y, z = self._right_angle(z_m, beam, beam.angle)
         elif fabs(angle_b % 180.0 - 90) <= ANGULAR_TOLERANCE or fabs(angle_b % 180.0 + 90) <= ANGULAR_TOLERANCE:
-            y, z = self._right_angle(z_b, self._position_at_zero, self._angle)
+            y, z = self._right_angle(z_b, self._current_position_at_zero, self._angle)
         else:
             tan_b = tan(radians(angle_b))
             tan_m = tan(radians(angle_m))
@@ -103,8 +104,8 @@ class LinearMovementCalc:
 
         """
         beam_intercept = self.calculate_interception(beam)
-        y_diff = self._position_at_zero.y - beam_intercept.y
-        z_diff = self._position_at_zero.z - beam_intercept.z
+        y_diff = self._current_position_at_zero.y - beam_intercept.y
+        z_diff = self._current_position_at_zero.z - beam_intercept.z
         dist_to_beam = sqrt(pow(y_diff, 2) + pow(z_diff, 2))
         if y_diff > 0:
             direction = -1.0
@@ -123,7 +124,7 @@ class LinearMovementCalc:
         if displacement is None:
             displacement = self._displacement
 
-        return self._position_at_zero + position_from_radial_coords(displacement, self._angle)
+        return self._current_position_at_zero + position_from_radial_coords(displacement, self._angle)
 
     def set_displacement(self, displacement):
         """
@@ -189,4 +190,4 @@ class LinearMovementCalc:
         Args:
             position_offset: The amount to change the zero position by.
         """
-        self._position_at_zero += position_offset
+        self._current_position_at_zero = self._initial_position_at_zero + position_offset

--- a/ReflectometryServer/movement_strategy.py
+++ b/ReflectometryServer/movement_strategy.py
@@ -34,7 +34,7 @@ class LinearMovementCalc:
         Args:
             beam (PositionAndAngle) : beam to intercept
 
-        Returns (float): position of the interception
+        Returns (Position): position of the interception
 
         """
         assert beam is not None
@@ -182,3 +182,11 @@ class LinearMovementCalc:
             (float): The sum of the position and distance along axis from 0 to beam intercept
         """
         return position + self._dist_along_axis_from_zero_to_beam_intercept(beam)
+
+    def offset_position_at_zero(self, position_offset: Position):
+        """
+        Offset the position at zero by the amount specified. Used to change where the movement axis is.
+        Args:
+            position_offset: The amount to change the zero position by.
+        """
+        self._position_at_zero += position_offset

--- a/ReflectometryServer/movement_strategy.py
+++ b/ReflectometryServer/movement_strategy.py
@@ -46,6 +46,8 @@ class LinearMovementCalc:
         z_b = beam.z
         angle_b = beam.angle
 
+        if z_b >= z_m:
+            raise ValueError("Component ordered incorrectly, has LONG_AXIS moved too far?")
         if fabs(angle_b % 180.0 - angle_m % 180.0) <= ANGULAR_TOLERANCE:
             raise ValueError("No interception between beam and movement")
         elif fabs(angle_b % 180.0) <= ANGULAR_TOLERANCE:

--- a/ReflectometryServer/parameters.py
+++ b/ReflectometryServer/parameters.py
@@ -488,8 +488,8 @@ class AxisParameter(BeamlineParameter):
         if description is None:
             description = name
         super(AxisParameter, self).__init__(name, description, autosave, rbv_to_sp_tolerance=rbv_to_sp_tolerance)
-        self._component = component
-        self._axis = axis
+        self.component = component
+        self.axis = axis
         if axis in [ChangeAxis.POSITION, ChangeAxis.ANGLE]:
             self.group_names.append(BeamlineParameterGroup.COLLIMATION_PLANE)
         else:
@@ -498,11 +498,11 @@ class AxisParameter(BeamlineParameter):
         if self._autosave:
             self._initialise_sp_from_file()
         if self._set_point_rbv is None:
-            self._component.beam_path_set_point.axis[self._axis].add_listener(InitUpdate,
-                                                                              self._initialise_sp_from_motor)
+            self.component.beam_path_set_point.axis[self.axis].add_listener(InitUpdate,
+                                                                            self._initialise_sp_from_motor)
 
-        self._component.beam_path_rbv.add_listener(BeamPathUpdate, self._on_update_rbv)
-        rbv_axis = self._component.beam_path_rbv.axis[self._axis]
+        self.component.beam_path_rbv.add_listener(BeamPathUpdate, self._on_update_rbv)
+        rbv_axis = self.component.beam_path_rbv.axis[self.axis]
         rbv_axis.add_listener(AxisChangingUpdate, self._on_update_changing_state)
         rbv_axis.add_listener(PhysicalMoveUpdate, self._on_update_rbv)
 
@@ -517,29 +517,29 @@ class AxisParameter(BeamlineParameter):
         sp_init = param_float_autosave.read_parameter(self._name, None)
         if sp_init is not None:
             self._set_initial_sp(sp_init)
-            self._component.beam_path_set_point.axis[self._axis].autosaved_value = sp_init
+            self.component.beam_path_set_point.axis[self.axis].autosaved_value = sp_init
             self._move_component()
 
     def _initialise_sp_from_motor(self, _):
         """
         Get the setpoint value for this parameter based on the motor setpoint position.
         """
-        if not self._component.beam_path_set_point.axis[self._axis].is_in_beam:
+        if not self.component.beam_path_set_point.axis[self.axis].is_in_beam:
             # If the axis is out of the beam the displacement should be set to 0
             init_sp = 0.0
         else:
-            init_sp = self._component.beam_path_set_point.axis[self._axis].get_relative_to_beam()
+            init_sp = self.component.beam_path_set_point.axis[self.axis].get_relative_to_beam()
 
         self._set_initial_sp(init_sp)
 
     def _move_component(self):
-        self._component.beam_path_set_point.axis[self._axis].set_relative_to_beam(self._set_point_rbv)
+        self.component.beam_path_set_point.axis[self.axis].set_relative_to_beam(self._set_point_rbv)
 
     def _rbv(self):
         """
         Returns: readback value for the parameter, e.g. tracking displacement above the beam
         """
-        return self._component.beam_path_rbv.axis[self._axis].get_relative_to_beam()
+        return self.component.beam_path_rbv.axis[self.axis].get_relative_to_beam()
 
     @property
     def rbv_at_sp(self):
@@ -550,21 +550,21 @@ class AxisParameter(BeamlineParameter):
         if self.rbv is None or self._set_point_rbv is None:
             return False
 
-        return not self._component.beam_path_set_point.axis[self._axis].is_in_beam or \
-            abs(self.rbv - self._set_point_rbv) < self._rbv_to_sp_tolerance
+        return not self.component.beam_path_set_point.axis[self.axis].is_in_beam or \
+               abs(self.rbv - self._set_point_rbv) < self._rbv_to_sp_tolerance
 
     def _get_alarm_info(self):
         """
         Returns the alarm information for the axis of this component.
         """
-        return self._component.beam_path_rbv.axis[self._axis].alarm
+        return self.component.beam_path_rbv.axis[self.axis].alarm
 
     @property
     def is_changing(self):
         """
         Returns: Is the parameter changing (e.g. rotating or displacing)
         """
-        return self._component.beam_path_rbv.axis[self._axis].is_changing
+        return self.component.beam_path_rbv.axis[self.axis].is_changing
 
     def validate(self, drivers):
         """

--- a/ReflectometryServer/test_modules/test_beam_path_calc.py
+++ b/ReflectometryServer/test_modules/test_beam_path_calc.py
@@ -1,17 +1,12 @@
 import unittest
 
-from math import tan, radians, isnan
 from hamcrest import *
-from mock import Mock, patch, call
-from parameterized import parameterized
 
-from ReflectometryServer.beam_path_calc import BeamPathUpdate, BeamPathCalcThetaSP, \
-    BeamPathCalcThetaRBV
+from ReflectometryServer.beam_path_calc import BeamPathCalcThetaSP, BeamPathCalcThetaRBV
 from ReflectometryServer.axis import BeamPathCalcAxis
-from ReflectometryServer.components import Component, ReflectingComponent, TiltingComponent, ThetaComponent
-from ReflectometryServer.geometry import Position, PositionAndAngle, ChangeAxis
+from ReflectometryServer.components import Component
+from ReflectometryServer.geometry import PositionAndAngle, ChangeAxis
 from ReflectometryServer.ioc_driver import CorrectedReadbackUpdate
-from ReflectometryServer.test_modules.utils import position_and_angle, position, DEFAULT_TEST_TOLERANCE
 
 
 class TestBeamPathCalc(unittest.TestCase):
@@ -56,7 +51,7 @@ class TestBeamPathCalc(unittest.TestCase):
 
         theta_sp = BeamPathCalcThetaSP("theta", None)
         comp = Component("comp", PositionAndAngle(0, 0, 0))
-        theta_sp.add_angle_to(comp.beam_path_rbv, ChangeAxis.CHI)
+        theta_sp.add_angle_to(comp.beam_path_rbv, [ChangeAxis.CHI])
 
         assert_that(calling(comp.beam_path_rbv.axis[ChangeAxis.CHI].init_displacement_from_motor).with_args(10),
                     raises(RuntimeError))

--- a/ReflectometryServer/test_modules/test_beam_path_calc.py
+++ b/ReflectometryServer/test_modules/test_beam_path_calc.py
@@ -65,7 +65,7 @@ class TestBeamPathCalc(unittest.TestCase):
 
         theta_sp = BeamPathCalcThetaRBV("theta", None, None)
         comp = Component("comp", PositionAndAngle(0, 0, 0))
-        theta_sp.add_angle_to(comp.beam_path_rbv, comp.beam_path_set_point, ChangeAxis.CHI)
+        theta_sp.add_angle_to(comp.beam_path_rbv, comp.beam_path_set_point, [ChangeAxis.CHI])
 
         assert_that(calling(comp.beam_path_rbv.axis[ChangeAxis.CHI].set_displacement).with_args(
             CorrectedReadbackUpdate(10, None, None)), raises(RuntimeError))

--- a/ReflectometryServer/test_modules/test_beamline.py
+++ b/ReflectometryServer/test_modules/test_beamline.py
@@ -264,6 +264,54 @@ class TestBeamlineValidation(unittest.TestCase):
             [driver],
             [mode]), raises(BeamlineConfigurationInvalidException))
 
+    def test_GIVEN_beamline_with_LONG_AXIS_parameter_before_POSITION_WHEN_construct_THEN_no_error(self):
+        mode = BeamlineMode("mode", [])
+        component = TiltingComponent("comp", PositionAndAngle(0, 0, 90))
+        beamline_parameters = [AxisParameter("param_1", component, ChangeAxis.LONG_AXIS),
+                               AxisParameter("param_2", component, ChangeAxis.POSITION)]
+
+        try:
+            Beamline([component], beamline_parameters, [], [mode])
+        except BeamlineConfigurationInvalidException:
+            assert_that(True, is_(False), "Beamline construction raised unexpected error")
+
+    def test_GIVEN_beamline_with_POSITION_parameter_before_LONG_AXIS_WHEN_construct_THEN_error(self):
+        mode = BeamlineMode("mode", [])
+        component = TiltingComponent("comp", PositionAndAngle(0, 0, 90))
+        beamline_parameters = [AxisParameter("param_1", component, ChangeAxis.POSITION),
+                               AxisParameter("param_2", component, ChangeAxis.LONG_AXIS)]
+        assert_that(calling(Beamline).with_args(
+            [component],
+            beamline_parameters,
+            [],
+            [mode]), raises(BeamlineConfigurationInvalidException))
+
+    def test_GIVEN_beamline_with_LONG_AXIS_driver_before_POSITION_WHEN_construct_THEN_no_error(self):
+        mode = BeamlineMode("mode", [])
+        component = TiltingComponent("comp", PositionAndAngle(0, 0, 90))
+        motor_axis = [create_mock_axis("axis_1", 0, 0),
+                      create_mock_axis("axis_2", 0, 0)]
+        drivers = [IocDriver(component, ChangeAxis.LONG_AXIS, motor_axis[0]),
+                   IocDriver(component, ChangeAxis.POSITION, motor_axis[1])]
+
+        try:
+            Beamline([component], [], drivers, [mode])
+        except BeamlineConfigurationInvalidException:
+            assert_that(True, is_(False), "Beamline construction raised unexpected error")
+
+    def test_GIVEN_beamline_with_POSITION_parameter_before_LONG_AXIS_WHEN_construct_THEN_error(self):
+        mode = BeamlineMode("mode", [])
+        component = TiltingComponent("comp", PositionAndAngle(0, 0, 90))
+        motor_axis = [create_mock_axis("axis_1", 0, 0),
+                      create_mock_axis("axis_2", 0, 0)]
+        drivers = [IocDriver(component, ChangeAxis.POSITION, motor_axis[0]),
+                   IocDriver(component, ChangeAxis.LONG_AXIS, motor_axis[1])]
+        assert_that(calling(Beamline).with_args(
+            [component],
+            [],
+            drivers,
+            [mode]), raises(BeamlineConfigurationInvalidException))
+
 
 class TestBeamlineModeInitialization(unittest.TestCase):
 

--- a/ReflectometryServer/test_modules/test_beamline_parameter.py
+++ b/ReflectometryServer/test_modules/test_beamline_parameter.py
@@ -588,7 +588,7 @@ class TestBeamlineParameterReadback(unittest.TestCase):
         displacement_parameter.add_listener(ParameterReadbackUpdate, listener)
         sample.beam_path_rbv.is_in_beam = state
 
-        listener.assert_called_once_with(ParameterReadbackUpdate(state, None, None))
+        listener.assert_called_with(ParameterReadbackUpdate(state, None, None))
 
     def test_GIVEN_theta_WHEN_no_next_component_THEN_value_is_nan(self):
 

--- a/ReflectometryServer/test_modules/test_components.py
+++ b/ReflectometryServer/test_modules/test_components.py
@@ -278,7 +278,8 @@ class TestThetaComponent(unittest.TestCase):
         next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
         next_component.beam_path_rbv.axis[ChangeAxis.POSITION].has_out_of_beam_position = True
         next_component.beam_path_rbv.axis[ChangeAxis.POSITION].is_in_beam = True
-        next_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(CorrectedReadbackUpdate(0, None, None))
+        next_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(
+            CorrectedReadbackUpdate(0, AlarmSeverity.No, AlarmStatus.No))
         theta.add_angle_to(next_component)
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 
@@ -295,7 +296,8 @@ class TestThetaComponent(unittest.TestCase):
         next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
         next_component.beam_path_rbv.axis[ChangeAxis.POSITION].has_out_of_beam_position = True
         next_component.beam_path_rbv.axis[ChangeAxis.POSITION].is_in_beam = True
-        next_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(CorrectedReadbackUpdate(5, None, None))
+        next_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(
+            CorrectedReadbackUpdate(5, AlarmSeverity.No, AlarmStatus.No))
         theta.add_angle_to(next_component)
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 
@@ -310,7 +312,8 @@ class TestThetaComponent(unittest.TestCase):
         next_component = Component("comp", setup=PositionAndAngle(0, 5, 90))
         next_component.beam_path_rbv.axis[ChangeAxis.POSITION].has_out_of_beam_position = True
         next_component.beam_path_rbv.axis[ChangeAxis.POSITION].is_in_beam = True
-        next_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(CorrectedReadbackUpdate(5, None, None))
+        next_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(
+            CorrectedReadbackUpdate(5, AlarmSeverity.No, AlarmStatus.No))
         theta.add_angle_to(next_component)
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 
@@ -329,7 +332,8 @@ class TestThetaComponent(unittest.TestCase):
         next_but_one_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
         next_but_one_component.beam_path_rbv.axis[ChangeAxis.POSITION].has_out_of_beam_position = True
         next_but_one_component.beam_path_rbv.axis[ChangeAxis.POSITION].is_in_beam = True
-        next_but_one_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(CorrectedReadbackUpdate(5, None, None))
+        next_but_one_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(
+            CorrectedReadbackUpdate(5, AlarmSeverity.No, AlarmStatus.No))
         next_component.beam_path_rbv.substitute_incoming_beam_for_displacement = "Not None"
 
         theta = ThetaComponent("theta", setup=PositionAndAngle(0, 5, 90))
@@ -355,7 +359,8 @@ class TestThetaComponent(unittest.TestCase):
         next_component.beam_path_rbv.axis[ChangeAxis.POSITION].has_out_of_beam_position = True
         next_component.beam_path_rbv.axis[ChangeAxis.POSITION].is_in_beam = True
         next_component.beam_path_rbv.substitute_incoming_beam_for_displacement = "Not None"
-        next_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(CorrectedReadbackUpdate(5, None, None))
+        next_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(
+            CorrectedReadbackUpdate(5, AlarmSeverity.No, AlarmStatus.No))
         theta.add_angle_to(next_component)
 
         next_but_one_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
@@ -383,14 +388,16 @@ class TestThetaComponent(unittest.TestCase):
         next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
         next_component.beam_path_rbv.axis[ChangeAxis.POSITION].has_out_of_beam_position = True
         next_component.beam_path_rbv.axis[ChangeAxis.POSITION].is_in_beam = True
-        next_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(CorrectedReadbackUpdate(0, None, None))
+        next_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(
+            CorrectedReadbackUpdate(0, AlarmSeverity.No, AlarmStatus.No))
         theta.add_angle_to(next_component)
 
         theta.beam_path_rbv.set_incoming_beam(beam_start)
         listener = Mock()
         theta.beam_path_rbv.add_listener(BeamPathUpdate, listener)
 
-        next_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(CorrectedReadbackUpdate(1, None, None))
+        next_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(
+            CorrectedReadbackUpdate(1, AlarmSeverity.No, AlarmStatus.No))
 
         listener.assert_called_with(BeamPathUpdate(theta.beam_path_rbv))
 
@@ -401,7 +408,8 @@ class TestThetaComponent(unittest.TestCase):
         next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
         next_component.beam_path_rbv.axis[ChangeAxis.POSITION].has_out_of_beam_position = True
         next_component.beam_path_rbv.axis[ChangeAxis.POSITION].is_in_beam = True
-        next_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(CorrectedReadbackUpdate(0, None, None))
+        next_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(
+            CorrectedReadbackUpdate(0, AlarmSeverity.No, AlarmStatus.No))
         theta.add_angle_to(next_component)
         theta.beam_path_rbv.set_incoming_beam(beam_start)
         listener = Mock()
@@ -418,7 +426,8 @@ class TestThetaComponent(unittest.TestCase):
         next_component = Component("comp", setup=PositionAndAngle(0, 10, 90))
         next_component.beam_path_rbv.axis[ChangeAxis.POSITION].has_out_of_beam_position = True
         next_component.beam_path_rbv.axis[ChangeAxis.POSITION].is_in_beam = True
-        next_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(CorrectedReadbackUpdate(15, None, None))
+        next_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(
+            CorrectedReadbackUpdate(15, AlarmSeverity.No, AlarmStatus.No))
         theta.add_angle_to(next_component)
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 
@@ -433,7 +442,8 @@ class TestThetaComponent(unittest.TestCase):
         next_component = TiltingComponent("comp", setup=PositionAndAngle(0, 10, 90))
         next_component.beam_path_rbv.axis[ChangeAxis.POSITION].has_out_of_beam_position = True
         next_component.beam_path_rbv.axis[ChangeAxis.POSITION].is_in_beam = True
-        next_component.beam_path_rbv.axis[ChangeAxis.ANGLE].set_displacement(CorrectedReadbackUpdate(45, None, None))
+        next_component.beam_path_rbv.axis[ChangeAxis.ANGLE].set_displacement(
+            CorrectedReadbackUpdate(45, AlarmSeverity.No, AlarmStatus.No))
         theta.add_angle_of(next_component)
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 
@@ -449,7 +459,8 @@ class TestThetaComponent(unittest.TestCase):
         next_component.beam_path_rbv.axis[ChangeAxis.POSITION].is_in_beam = True
         theta.add_angle_to(next_component)
         expected_position = 5
-        next_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(CorrectedReadbackUpdate(expected_position, None, None))
+        next_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(
+            CorrectedReadbackUpdate(expected_position, AlarmSeverity.No, AlarmStatus.No))
 
         theta.beam_path_set_point.set_incoming_beam(beam_start)
         theta.beam_path_set_point.axis[ChangeAxis.ANGLE].set_relative_to_beam(0)
@@ -470,8 +481,10 @@ class TestThetaComponent(unittest.TestCase):
         next_component.beam_path_rbv.axis[ChangeAxis.POSITION].has_out_of_beam_position = True
         next_component.beam_path_rbv.axis[ChangeAxis.POSITION].is_in_beam = True
         next_component.beam_path_rbv.incoming_beam_can_change = False
-        next_component.beam_path_rbv.axis[ChangeAxis.ANGLE].set_displacement(CorrectedReadbackUpdate(0, None, None))
-        next_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(CorrectedReadbackUpdate(5, None, None))
+        next_component.beam_path_rbv.axis[ChangeAxis.ANGLE].set_displacement(
+            CorrectedReadbackUpdate(0, AlarmSeverity.No, AlarmStatus.No))
+        next_component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(
+            CorrectedReadbackUpdate(5, AlarmSeverity.No, AlarmStatus.No))
         theta.add_angle_to(next_component)
         theta.beam_path_rbv.set_incoming_beam(beam_start)
 
@@ -657,6 +670,7 @@ class TestComponentAlarms(unittest.TestCase):
         self.theta.add_angle_to(self.component)
         update = CorrectedReadbackUpdate(0, self.ALARM_SEVERITY, self.ALARM_STATUS)
 
+        self.component.beam_path_rbv.axis[ChangeAxis.LONG_AXIS].set_alarm(AlarmSeverity.No, AlarmStatus.No)
         self.component.beam_path_rbv.axis[ChangeAxis.POSITION].set_displacement(update)
         actual_alarm_info = self.theta.beam_path_rbv.axis[ChangeAxis.ANGLE].alarm
 

--- a/ReflectometryServer/test_modules/test_ioc_driving_layer.py
+++ b/ReflectometryServer/test_modules/test_ioc_driving_layer.py
@@ -444,6 +444,8 @@ class BeamlineMoveDurationTest(unittest.TestCase):
         slit_2_height_axis = create_mock_axis("SLIT2:HEIGHT", 0.0, 10.0)
         self.slit_2_driver = MagicMock(IocDriver)
         self.slit_2_driver.get_max_move_duration = MagicMock(return_value=0)
+        self.slit_2_driver.component = slit_2
+        self.slit_2_driver.component_axis = ChangeAxis.POSITION
 
         slit_3 = Component("slit_3", setup=PositionAndAngle(y=0.0, z=30.0, angle=90.0))
         slit_3_height_axis = create_mock_axis("SLIT3:HEIGHT", 0.0, 10.0)

--- a/ReflectometryServer/test_modules/test_movement.py
+++ b/ReflectometryServer/test_modules/test_movement.py
@@ -287,20 +287,6 @@ class TestMovementRelativeToBeam(unittest.TestCase):
 
         assert_that(result, is_(position(Position(beam_intercept.y - dist/2.0, beam_intercept.z + dist * sqrt(3)/2.0))))
 
-    @parameterized.expand([(0,), (360,), (-360,)])
-    def test_GIVEN_movement_at_minus_180_and_similar_to_z_beam_intercept_to_the_right_of_zero_WHEN_set_position_relative_to_beam_to_10_THEN_position_is_at_10_along_intercept(self, add_angle):
-        # here the beam intercept is above and to the right of the zero point
-        movement = LinearMovementCalc(PositionAndAngle(0, 10, 180 + add_angle))
-        y_diff = 2.0
-        beam = PositionAndAngle(0, 10 + y_diff, 90)
-        beam_intercept = Position(0, 10 + y_diff)
-        dist = 10
-
-        movement.set_distance_relative_to_beam(beam, dist)
-        result = movement.position_in_mantid_coordinates()
-
-        assert_that(result, is_(position(Position(beam_intercept.y, beam_intercept.z - dist))))
-
 
 class TestMovementValueObserver(unittest.TestCase):
 

--- a/ReflectometryServer/test_modules/test_movement.py
+++ b/ReflectometryServer/test_modules/test_movement.py
@@ -129,6 +129,51 @@ class TestMovementIntercept(unittest.TestCase):
 
         assert_that(result, is_(position(Position(displacement, z))))
 
+    def test_GIVEN_movement_45_to_z_at_beam_along_z_WHEN_z_of_movement_axis_changes_THEN_position_is_new_z(self):
+        y = 0
+        z = 7
+        z_offset = 9
+        movement = LinearMovementCalc(PositionAndAngle(y, z, 45))
+        beam = PositionAndAngle(y, 0, 0)
+
+        result = movement.calculate_interception(beam)
+        assert_that(result, is_(position(Position(y, z))))
+
+        movement.offset_position_at_zero(Position(0, z_offset))
+
+        result = movement.calculate_interception(beam)
+        assert_that(result, is_(position(Position(y, z + z_offset))))
+
+    def test_GIVEN_movement_45_to_z_at_beam_offset_along_z_WHEN_z_of_movement_axis_changes_THEN_position_is_as_expected(self):
+        y = 0
+        z = 7
+        z_offset = 9
+        beam_y = 5
+        movement = LinearMovementCalc(PositionAndAngle(y, z, 45))
+        beam = PositionAndAngle(beam_y, 0, 0)
+
+        result = movement.calculate_interception(beam)
+        assert_that(result, is_(position(Position(beam_y, z + beam_y))))
+
+        movement.offset_position_at_zero(Position(0, z_offset))
+
+        result = movement.calculate_interception(beam)
+        assert_that(result, is_(position(Position(beam_y, z + beam_y + z_offset))))
+
+    def test_GIVEN_movement_perp_to_z_at_beam_angle_45_WHEN_z_of_movement_axis_changes_THEN_position_is_as_expected(self):
+        y = 0
+        z = 7
+        z_offset = 9
+        movement = LinearMovementCalc(PositionAndAngle(y, z, 90))
+        beam = PositionAndAngle(0, 0, 45)
+
+        result = movement.calculate_interception(beam)
+        assert_that(result, is_(position(Position(z, z))))
+
+        movement.offset_position_at_zero(Position(0, z_offset))
+
+        result = movement.calculate_interception(beam)
+        assert_that(result, is_(position(Position(z + z_offset, z + z_offset))))
 
 
 class TestMovementRelativeToBeam(unittest.TestCase):

--- a/ReflectometryServer/test_modules/test_movement.py
+++ b/ReflectometryServer/test_modules/test_movement.py
@@ -11,6 +11,12 @@ from ReflectometryServer.test_modules.utils import position
 
 class TestMovementIntercept(unittest.TestCase):
 
+    def test_GIVEN_incoming_beam_after_component_WHEN_get_intercept_THEN_raises_value_error(self):
+        movement = LinearMovementCalc(PositionAndAngle(1, 1, 90))
+        beam = PositionAndAngle(0, 2, 0)
+
+        assert_that(calling(movement.calculate_interception).with_args(beam), raises(ValueError))
+
     def test_GIVEN_movement_and_beam_at_the_same_angle_WHEN_get_intercept_THEN_raises_calc_error(self):
         angle = 12.3
         movement = LinearMovementCalc(PositionAndAngle(1, 1, angle))

--- a/run_all_tests.py
+++ b/run_all_tests.py
@@ -61,9 +61,9 @@ if __name__ == '__main__':
 
     # Python 2 coverage analysis does not understand the Py3 code in some modules, and crashes out.
     with nullcontext() if six.PY2 else coverage_analysis():
-        print("\n\n------ BEGINNING INST SERVERS UNIT TESTS ------")
+        print("\n\n------ BEGINNING REFLECTOMETRY UNIT TESTS ------")
         ret_vals = xmlrunner.XMLTestRunner(output=xml_dir, verbosity=2).run(test_suite)
-        print("------ INST SERVERS UNIT TESTS COMPLETE ------\n\n")
+        print("------ REFLECTOMETRY UNIT TESTS COMPLETE ------\n\n")
 
     # Return failure exit code if a test errored or failed
     sys.exit(bool(ret_vals.errors or ret_vals.failures))


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/5896

To test:

With a config like:
```
def get_beamline(macros):
    z_sm = 5.0
    z_s1 = 10.0

    # Modes
    nr = add_mode("NR")

    add_constant(BeamlineConstant("SM_Z", z_sm, "Super mirror z position"))
    sm_comp = add_component(ReflectingComponent("sm", PositionAndAngle(0.0, z_sm, 90)))

    add_parameter(InBeamParameter("SMInBeam", sm_comp, autosave=True),
                  modes=[nr], mode_inits=[(nr, True)])
    add_parameter(AxisParameter("SMOffset", sm_comp, ChangeAxis.POSITION, autosave=True), modes=[nr])
    add_parameter(AxisParameter("SMAngle", sm_comp, ChangeAxis.ANGLE, autosave=True), modes=[nr])

    add_driver(IocDriver(sm_comp, ChangeAxis.POSITION, MotorPVWrapper("MOT:MTR0101"),
                         out_of_beam_positions=[OutOfBeamPosition(position=-47.0)], synchronised=False))
    add_driver(IocDriver(sm_comp, ChangeAxis.ANGLE, MotorPVWrapper("MOT:MTR0102"), synchronised=False))

    # Slit 1
    #  - tracking
    add_constant(BeamlineConstant("S1_Z", z_s1, "Slit 1 z position"))
    s1_comp = add_component(Component("s1", PositionAndAngle(0.0, z_s1, 90)))

    add_parameter(AxisParameter("S1_Z", s1_comp, ChangeAxis.LONG_AXIS, autosave=True), modes=[nr])
    add_parameter(AxisParameter("S1Offset", s1_comp, ChangeAxis.POSITION, autosave=True), modes=[nr])

    add_driver(IocDriver(s1_comp, ChangeAxis.LONG_AXIS, MotorPVWrapper("MOT:MTR0104")))
    add_driver(IocDriver(s1_comp, ChangeAxis.POSITION, MotorPVWrapper("MOT:MTR0103")))

    add_beam_start(PositionAndAngle(5.0, 0.0, -45.0))

    return get_configured_beamline()
```
Move S1_Z and confirm that `S1Offset` continues to track the beam