### PR TITLE
Ticket6000 archive

### DIFF
--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -154,7 +154,7 @@ class PVManager:
         self._add_pv_with_fields(SERVER_MESSAGE, None, {'type': 'char', 'count': 400}, "Message about the beamline",
                                  PvSort.RBV, archive=True, interest="HIGH", on_init=True)
         self._add_pv_with_fields(SERVER_ERROR_LOG, None, {'type': 'char', 'count': 10000},
-                                 "Error log for the Reflectometry Server", PvSort.RBV, archive=True, interest="HIGH",
+                                 "Error log for the Reflectometry Server", PvSort.RBV, interest="HIGH",
                                  on_init=True)
 
     def set_beamline(self, beamline):

--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -415,7 +415,8 @@ class PVManager:
                     fields = STANDARD_FLOAT_PV_FIELDS
 
                 self._add_pv_with_fields(prepended_alias, None, fields, beamline_constant.description, None,
-                                         archive=True, interest="MEDIUM", value=value)
+                                         interest="MEDIUM", value=value)
+                logger.info("Adding Constant {} with value {}".format(beamline_constant.name, beamline_constant.value))
                 beamline_constant_info.append(
                     {"name": beamline_constant.name, "prepended_alias": prepended_alias, "type": "float_value"})
             except Exception as err:

--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -152,7 +152,7 @@ class PVManager:
         self._add_pv_with_fields(SERVER_STATUS, None, status_fields, "Status of the beam line", PvSort.RBV,
                                  archive=True, interest="HIGH", alarm=True, on_init=True)
         self._add_pv_with_fields(SERVER_MESSAGE, None, {'type': 'char', 'count': 400}, "Message about the beamline",
-                                 PvSort.RBV, archive=True, interest="HIGH", on_init=True)
+                                 PvSort.RBV, interest="HIGH", on_init=True)
         self._add_pv_with_fields(SERVER_ERROR_LOG, None, {'type': 'char', 'count': 10000},
                                  "Error log for the Reflectometry Server", PvSort.RBV, interest="HIGH",
                                  on_init=True)

--- a/ReflectometryServer/server_status_manager.py
+++ b/ReflectometryServer/server_status_manager.py
@@ -214,6 +214,8 @@ class _ServerStatusManager:
     @message.setter
     def message(self, message_to_set):
         self._message = message_to_set
+        logger.info("New Status Message:")
+        logger.info("{}".format(message_to_set))
         self._trigger_status_update()
 
     @property


### PR DESCRIPTION
Do not archive char waveform PVs. (see: https://github.com/ISISComputingGroup/IBEX/issues/6000#issuecomment-761580131)

In the case of beamline constants, the (fixed) values are now written to the IOC log on startup so the information is preserved.
The information in the error log PV is already duplicated from the IOC log.

Issue:  https://github.com/ISISComputingGroup/IBEX/issues/6000