### PR TITLE
Fix optional macros

### DIFF
--- a/ReflectometryServer/config_helper.py
+++ b/ReflectometryServer/config_helper.py
@@ -376,7 +376,17 @@ def optional_is_set(optional_id, macros):
     """
     try:
         macro_name = "OPTIONAL_{}".format(optional_id)
-        return macros[macro_name]
+        macro_value = macros[macro_name]
+        if macro_value.lower() == "true":
+            return True
+        elif macro_value.lower() == "false":
+            return False
+        else:
+            STATUS_MANAGER.update_error_log(
+                ("Invalid value for IOC macro {}: {} (Expected: True/False)".format(macro_name, macro_value)))
+            STATUS_MANAGER.update_active_problems(
+                ProblemInfo("Invalid IOC macro value", macro_name, Severity.MINOR_ALARM))
+            return False
     except KeyError:
         return False
 

--- a/ReflectometryServer/config_helper.py
+++ b/ReflectometryServer/config_helper.py
@@ -3,6 +3,8 @@ Objects to help configure the beamline
 """
 from typing import Dict, Optional, List, Any, Union
 
+from pcaspy import Severity
+
 from ReflectometryServer import Beamline, BeamlineMode, SlitGapParameter, JawsGapPVWrapper, JawsCentrePVWrapper, \
     PVWrapper, MotorPVWrapper, ConstantCorrection, ModeSelectCorrection
 from ReflectometryServer.geometry import PositionAndAngle
@@ -11,6 +13,7 @@ import six
 
 from ReflectometryServer.parameters import DEFAULT_RBV_TO_SP_TOLERANCE, EnumParameter, DirectParameter, \
     BeamlineParameter
+from ReflectometryServer.server_status_manager import STATUS_MANAGER, ProblemInfo
 
 logger = logging.getLogger(__name__)
 

--- a/ReflectometryServer/test_modules/test_config_helper.py
+++ b/ReflectometryServer/test_modules/test_config_helper.py
@@ -385,7 +385,7 @@ class TestConfigHelper(unittest.TestCase):
         assert_that(actual, is_(expected))
 
     def test_GIVEN_optional_is_set_to_true_WHEN_checking_optional_is_set_THEN_return_true(self):
-        macros = {"OPTIONAL_1": True}
+        macros = {"OPTIONAL_1": "True"}
         optional_id = 1
         expected = True
 
@@ -394,7 +394,16 @@ class TestConfigHelper(unittest.TestCase):
         assert_that(actual, is_(expected))
 
     def test_GIVEN_optional_is_set_to_false_WHEN_checking_optional_is_set_THEN_return_false(self):
-        macros = {"OPTIONAL_1": False}
+        macros = {"OPTIONAL_1": "False"}
+        optional_id = 1
+        expected = False
+
+        actual = optional_is_set(optional_id, macros)
+
+        assert_that(actual, is_(expected))
+
+    def test_GIVEN_optional_is_set_to_nonsense_WHEN_checking_optional_is_set_THEN_return_false(self):
+        macros = {"OPTIONAL_1": "Nonsense"}
         optional_id = 1
         expected = False
 


### PR DESCRIPTION
Helper method treated `macros` dict as if the `value`s were boolean, but they are string. This PR parses them correctly and adds better error handling.