### PR TITLE
Ticket6472 component ordering

### DIFF
--- a/ReflectometryServer/movement_strategy.py
+++ b/ReflectometryServer/movement_strategy.py
@@ -46,8 +46,6 @@ class LinearMovementCalc:
         z_b = beam.z
         angle_b = beam.angle
 
-        if z_b > z_m:
-            raise ValueError("Component ordered incorrectly, has LONG_AXIS moved too far?")
         if fabs(angle_b % 180.0 - angle_m % 180.0) <= ANGULAR_TOLERANCE:
             raise ValueError("No interception between beam and movement")
         elif fabs(angle_b % 180.0) <= ANGULAR_TOLERANCE:

--- a/ReflectometryServer/test_modules/test_beamline.py
+++ b/ReflectometryServer/test_modules/test_beamline.py
@@ -240,14 +240,16 @@ class TestRealistic(unittest.TestCase):
                         is_(position_and_angle(component.beam_path_rbv._incoming_beam)),
                         "call autosaving {}".format(save_name))
 
-
-    def test_GIVEN_negative_sm_angle_WHEN_calculating_bench_intercept_THEN_no_error_thrown(self):
+    def test_GIVEN_negative_sm_angle_WHEN_calculating_bench_intercept_THEN_value_accepted_and_no_error_thrown(self):
         expected_theta = 0.2
         driver_bench_offset = 0
+        sm_angle_to_set = -0.1
 
         bl, drives = DataMother.beamline_sm_theta_bench(0.0, expected_theta, driver_bench_offset,
                                                         natural_angle=2.3)
-        bl.parameter("sm_angle").sp = -0.1
+        bl.parameter("sm_angle").sp = sm_angle_to_set
+
+        assert_that(bl.parameter("sm_angle").sp_rbv, is_(sm_angle_to_set))
 
 
 class TestBeamlineValidation(unittest.TestCase):

--- a/ReflectometryServer/test_modules/test_beamline.py
+++ b/ReflectometryServer/test_modules/test_beamline.py
@@ -241,6 +241,15 @@ class TestRealistic(unittest.TestCase):
                         "call autosaving {}".format(save_name))
 
 
+    def test_GIVEN_negative_sm_angle_WHEN_calculating_bench_intercept_THEN_no_error_thrown(self):
+        expected_theta = 0.2
+        driver_bench_offset = 0
+
+        bl, drives = DataMother.beamline_sm_theta_bench(0.0, expected_theta, driver_bench_offset,
+                                                        natural_angle=2.3)
+        bl.parameter("sm_angle").sp = -0.1
+
+
 class TestBeamlineValidation(unittest.TestCase):
 
     def test_GIVEN_two_beamline_parameters_with_same_name_WHEN_construct_THEN_error(self):

--- a/ReflectometryServer/test_modules/test_movement.py
+++ b/ReflectometryServer/test_modules/test_movement.py
@@ -11,12 +11,6 @@ from ReflectometryServer.test_modules.utils import position
 
 class TestMovementIntercept(unittest.TestCase):
 
-    def test_GIVEN_incoming_beam_after_component_WHEN_get_intercept_THEN_raises_value_error(self):
-        movement = LinearMovementCalc(PositionAndAngle(1, 1, 90))
-        beam = PositionAndAngle(0, 2, 0)
-
-        assert_that(calling(movement.calculate_interception).with_args(beam), raises(ValueError))
-
     def test_GIVEN_movement_and_beam_at_the_same_angle_WHEN_get_intercept_THEN_raises_calc_error(self):
         angle = 12.3
         movement = LinearMovementCalc(PositionAndAngle(1, 1, angle))


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/5896 introduced a check for components to come after their incoming beam in Z (=distance along the beam). This is an unlikely condition to be hit by the INTER long axis and was put in as a safeguard for future beamlines where they might move components more regularly along the Z axis.

The reason I remove it here is because it was creating issues on POLREF because:
- the "position" of the bench is defined as it's pivot (i.e. the Sample) 
- the outgoing beam at the sample is changing in Z depending on the supermirror angle before it, as the tracking sample height does not move perpendicular to the beam, but at an angle of 2.3 deg
- as a result, the Z coordinate of the outgoing beam at the sample may be past the "start" of the bench, leading to the server rejecting setpoints.

Note that the bench tracking is correct. If we want to reinstate the check for the long axis in the future we will need to revisit this, but at the moment it is not worth spending a lot of time on.

Ticket: https://github.com/ISISComputingGroup/IBEX/issues/6472