### PR TITLE
pick up new velocity to restore at runtime

### DIFF
--- a/ReflectometryServer/pv_wrapper.py
+++ b/ReflectometryServer/pv_wrapper.py
@@ -207,7 +207,7 @@ class PVWrapper:
         self._moving_direction_cache = self._read_pv(self._dir_pv)
         self._max_velocity_cache = self._read_pv(self._vmax_pv)
         self._base_velocity_cache = self._read_pv(self._vbas_pv)
-        self._init_velocity_cache()
+        self._init_velocity_to_restore()
         self._add_monitors()
 
     def _add_monitors(self):
@@ -376,7 +376,7 @@ class PVWrapper:
         """
         return self._moving_direction_cache
 
-    def _init_velocity_cache(self):
+    def _init_velocity_to_restore(self):
         """
         Initialise the velocity cache for the current axis.
 
@@ -518,6 +518,9 @@ class PVWrapper:
             alarm_status (server_common.channel_access.AlarmCondition): the alarm status
         """
         self._velocity_cache = value
+        if self._velocity_restored or (self._velocity_restored is None and not self.is_moving):
+            self._velocity_to_restore = value
+            logger.info("{}: Changed velocity to restore. New value: {} ".format(self._name, value))
 
     @property
     def is_moving(self):


### PR DESCRIPTION
When the reflectometry server does a synchronized move, it calculates the velocity for each axis involved in this move (usually slower than max) to ensure every axis finishes moving around the same time, and afterwards restores the axis velocity to the value of `velocity_to_restore`. 

Previously, `velocity_to_restore` was only set on startup and at the start of a move - with this change, the reflectometry server can now pick up when the velocity is changed outside of the refl server at the motor level. Breakdown of the conditional:

- `if self._velocity_restored` 
Change `velocity_to_restore` if it has been restored from the last move (i.e. we are not currently in the middle of a move)

- `or (self._velocity_restored is None and not self.is_moving)`:
Also change `velocity_to_restore` if `velocity_restored` has not been set, i.e. the restored status has not been read from the autosave file - this can happen on new instruments / on axes newly added to the reflectometry config / in system tests. The `is_moving` part protects against an edge case where someone or something could theoretically try to set a velocity on a motor that is in the middle of a move, but just after server startup before the autosave file is read (i.e. `velocity_restored` is still `None` but should be `False`)


also renamed `init_velocity_cache` to be in line with the variable naming throughout the rest of this file (anything `_cache` is used to mean values cached from motor fields that we don't want to `caget` every time we need them in the reflectometry server)

For: https://github.com/ISISComputingGroup/IBEX/issues/6950