### PR TITLE
Ticket7215_Reflectometry_Wrong_Velocity_Being_Cached

### DIFF
--- a/ReflectometryServer/run_tests.py
+++ b/ReflectometryServer/run_tests.py
@@ -14,7 +14,7 @@
 # https://www.eclipse.org/org/documents/epl-v10.php or
 # http://opensource.org/licenses/eclipse-1.0.php
 """
-Runn all the tests for refl server
+Run all the tests for refl server
 """
 # Standard imports
 import unittest

--- a/ReflectometryServer/test_modules/data_mother.py
+++ b/ReflectometryServer/test_modules/data_mother.py
@@ -482,7 +482,7 @@ class MockChannelAccess:
         except KeyError:
             return None
 
-    def caput(self, pv, value):
+    def caput(self, pv, value, wait=False, safe_not_quick=False):
         self._pvs[pv] = value
 
 


### PR DESCRIPTION
    added initialisation of self._moving_state_cache from the PV. The value can otherwise be None.
    The test in _on_update_moving_state for this value to be not None is, I think, no longer required. Instead a test that the state was moving, and is now not moving.
    The new_value can be a float (0.0 or 1.0), whereas it should be treated as an enum (integer).

In test_pv_wrapper.py:
    Added test that exercises wrapper.cache_velocity() and wrapper.restore_pre_move_velocity().

In data_mother.py:
    caput requires keyword parameters in order to accommodate wait passed from _write_pv.