### PR TITLE
Ticket7649 expose beam path

### DIFF
--- a/ReflectometryServer/ChannelAccess/driver_utils.py
+++ b/ReflectometryServer/ChannelAccess/driver_utils.py
@@ -97,6 +97,7 @@ class PvSort(Enum):
     DEFINE_POS_ACTION = 12
     DEFINE_POS_CHANGED = 13
     LOCKED = 14
+    READ_ONLY = 15
 
     @staticmethod
     def what(pv_sort):
@@ -134,6 +135,8 @@ class PvSort(Enum):
             return "(The current position definition is changed)"
         elif pv_sort == PvSort.LOCKED:
             return "(Locked)"
+        elif pv_sort == PvSort.READ_ONLY:
+            return "(Is not settable by user)"
         else:
             print_and_log("Unknown pv sort!! {}".format(pv_sort), severity=SEVERITY.MAJOR, src="REFL")
             return "(unknown)"
@@ -186,6 +189,8 @@ class PvSort(Enum):
             value = parameter.define_current_value_as.changed
         elif self == PvSort.LOCKED:
             value = parameter.is_locked
+        elif self == PvSort.READ_ONLY:
+            value = parameter.read_only
         else:
             value, severity, status = float("NaN"), AlarmSeverity.Invalid, AlarmStatus.UDF
             STATUS_MANAGER.update_error_log("PVSort not understood {}".format(PvSort))

--- a/ReflectometryServer/ChannelAccess/pv_manager.py
+++ b/ReflectometryServer/ChannelAccess/pv_manager.py
@@ -88,6 +88,7 @@ DEFINE_POS_SET_AND_NO_ACTION = ":DEFINE_POS_SET_AND_NO_ACTION"
 DEFINE_POS_ACTION = ":DEFINE_POS_ACTION"
 DEFINE_POS_CHANGED = ":DEFINE_POS_CHANGED"
 LOCKED = ":LOCKED"
+READ_ONLY = ":READ_ONLY"
 
 VAL_FIELD = ".VAL"
 STAT_FIELD = ".STAT"
@@ -97,7 +98,8 @@ DISP_FIELD = ".DISP"
 EGU_FIELD = ".EGU"
 
 ALL_PARAM_SUFFIXES = [VAL_FIELD, STAT_FIELD, SEVR_FIELD, DISP_FIELD, EGU_FIELD, DESC_FIELD, SP_SUFFIX, SP_RBV_SUFFIX,
-                      SET_AND_NO_ACTION_SUFFIX, CHANGED_SUFFIX, ACTION_SUFFIX, CHANGING, IN_MODE_SUFFIX, RBV_AT_SP, LOCKED]
+                      SET_AND_NO_ACTION_SUFFIX, CHANGED_SUFFIX, ACTION_SUFFIX, CHANGING, IN_MODE_SUFFIX, RBV_AT_SP,
+                      LOCKED, READ_ONLY]
 
 CONST_PREFIX = "CONST"
 
@@ -335,6 +337,9 @@ class PVManager:
         self._add_pv_with_fields(prepended_alias + LOCKED, param_name, PARAM_FIELDS_BINARY_WITH_MANAGER, description,
                                  PvSort.LOCKED)
 
+        # Read Only PV
+        self._add_pv_with_fields(prepended_alias + READ_ONLY, param_name, PARAM_FIELDS_BINARY_WITH_MANAGER, description,
+                                 PvSort.READ_ONLY)
         # define position at
         if parameter.define_current_value_as is not None:
             self._add_pv_with_fields(prepended_alias + DEFINE_POS_SP, param_name, STANDARD_FLOAT_PV_FIELDS_WITH_MANAGER, description,

--- a/ReflectometryServer/axis.py
+++ b/ReflectometryServer/axis.py
@@ -519,14 +519,13 @@ class BeamPathCalcAxis(ComponentAxis):
 class ReadOnlyBeamPathCalcAxis(BeamPathCalcAxis):
 
     def __init__(self, axis, get_relative_to_beam):
-        super(ReadOnlyBeamPathCalcAxis, self).__init__(axis, get_relative_to_beam, self._do_nothing_function)
+        super(ReadOnlyBeamPathCalcAxis, self).__init__(axis, get_relative_to_beam, self._do_nothing_function,
+                                                       get_displacement=get_relative_to_beam,
+                                                       set_displacement=self._do_nothing_function)
         self.set_alarm(AlarmSeverity.No, AlarmStatus.No)
 
     def get_displacement(self):
         return self.get_relative_to_beam()
-
-    def set_displacement(self, _):
-        pass
 
     def init_displacement_from_motor(self, _):
         pass

--- a/ReflectometryServer/axis.py
+++ b/ReflectometryServer/axis.py
@@ -514,3 +514,23 @@ class BeamPathCalcAxis(ComponentAxis):
         if self._init_displacement_from_motor is not None:
             return self._init_displacement_from_motor(value)
         raise TypeError("Axis does not support init_displacement_from_motor")
+
+
+class ReadOnlyBeamPathCalcAxis(BeamPathCalcAxis):
+
+    def __init__(self, axis, get_relative_to_beam):
+        super(ReadOnlyBeamPathCalcAxis, self).__init__(axis, get_relative_to_beam, self._do_nothing_function)
+        self.set_alarm(AlarmSeverity.No, AlarmStatus.No)
+
+    def get_displacement(self):
+        return self.get_relative_to_beam()
+
+    def set_displacement(self, _):
+        pass
+
+    def init_displacement_from_motor(self, _):
+        pass
+
+    def _do_nothing_function(self, _):
+        pass
+

--- a/ReflectometryServer/geometry.py
+++ b/ReflectometryServer/geometry.py
@@ -107,6 +107,5 @@ class ChangeAxis(Enum):
     JACK_FRONT = 9  # on the bench the jack at the front of the table
     JACK_REAR = 10  # on the bench the jack at the rear of the table
     SLIDE = 11      # on the bench the horizontal slide
-    OUT_BEAM_Y = 12
-    OUT_BEAM_Z = 13
-    OUT_BEAM_ANGLE = 14
+    DISPLACEMENT_POSITION = 12
+    DISPLACEMENT_ANGLE = 13

--- a/ReflectometryServer/geometry.py
+++ b/ReflectometryServer/geometry.py
@@ -107,3 +107,6 @@ class ChangeAxis(Enum):
     JACK_FRONT = 9  # on the bench the jack at the front of the table
     JACK_REAR = 10  # on the bench the jack at the rear of the table
     SLIDE = 11      # on the bench the horizontal slide
+    OUT_BEAM_Y = 12
+    OUT_BEAM_Z = 13
+    OUT_BEAM_ANGLE = 14

--- a/ReflectometryServer/parameters.py
+++ b/ReflectometryServer/parameters.py
@@ -247,10 +247,6 @@ class BeamlineParameter:
         self._set_point = None
         self._set_point_rbv = None
         self.read_only = False
-        # TODO
-        # init from file: error
-        # init from motor: equal to rbv
-        # refactor into subclass?
 
         self._sp_is_changed = False
         self._name = name
@@ -260,12 +256,12 @@ class BeamlineParameter:
         self.alarm_status = None
         self.alarm_severity = None
         self.parameter_type = BeamlineParameterType.FLOAT
+        self._add_to_parameter_groups()
         if description is None:
             self.description = name
         else:
             self.description = description
         self._autosave = autosave
-        self.group_names = [BeamlineParameterGroup.ALL]
         self._rbv_to_sp_tolerance = rbv_to_sp_tolerance
 
         self.define_current_value_as = None
@@ -276,6 +272,12 @@ class BeamlineParameter:
     def __repr__(self):
         return "{} '{}': sp={}, sp_rbv={}, rbv={}, changed={}".format(__name__, self.name, self._set_point,
                                                                       self._set_point_rbv, self.rbv, self.sp_changed)
+
+    def _add_to_parameter_groups(self):
+        """
+        Add this parameter to relevant parameter groups (for display purposes).
+        """
+        self.group_names = [BeamlineParameterGroup.ALL]
 
     @abc.abstractmethod
     def _initialise_sp_from_file(self):
@@ -608,8 +610,11 @@ class VirtualParameter(BeamlineParameter):
         super(VirtualParameter, self).__init__(name, description=description, autosave=True)
         self.engineering_unit = engineering_unit
 
-        self.group_names.append(BeamlineParameterGroup.MISC)
         self._initialise_sp_from_file()
+
+    def _add_to_parameter_groups(self):
+        super()._add_to_parameter_groups()
+        self.group_names.append(BeamlineParameterGroup.MISC)
 
     def _initialise_sp_from_file(self):
         """
@@ -665,24 +670,20 @@ class AxisParameter(BeamlineParameter):
             sp_mirrors_rbv: if True the sp gets set to the readback value when this parameter is asked to perform a
                 move; False this doesn't happen
         """
+        self.component = component
+        self.axis = axis
         if description is None:
             description = name
         super(AxisParameter, self).__init__(name, description, autosave, rbv_to_sp_tolerance=rbv_to_sp_tolerance,
                                             custom_function=custom_function, characteristic_value=characteristic_value,
                                             sp_mirrors_rbv=sp_mirrors_rbv)
-        self.component = component
-        self.axis = axis
-        if axis in [ChangeAxis.POSITION, ChangeAxis.ANGLE]:
-            self.group_names.append(BeamlineParameterGroup.COLLIMATION_PLANE)
-        else:
-            self.group_names.append(BeamlineParameterGroup.MISC)
 
-        if axis in [ChangeAxis.ANGLE, ChangeAxis.PHI, ChangeAxis.PSI, ChangeAxis.CHI, ChangeAxis.OUT_BEAM_ANGLE]:
+        if axis in [ChangeAxis.ANGLE, ChangeAxis.PHI, ChangeAxis.PSI, ChangeAxis.CHI, ChangeAxis.DISPLACEMENT_ANGLE]:
             self.engineering_unit = "deg"
         else:
             self.engineering_unit = "mm"
 
-        if axis in [ChangeAxis.OUT_BEAM_Y, ChangeAxis.OUT_BEAM_Z, ChangeAxis.OUT_BEAM_ANGLE]:
+        if axis in [ChangeAxis.DISPLACEMENT_POSITION, ChangeAxis.DISPLACEMENT_ANGLE]:
             self.read_only = True
             self._trigger_listeners_disabled()
             self.component.beam_path_set_point.axis[self.axis].add_listener(SetRelativeToBeamUpdate, self._update_sp_from_component)
@@ -690,6 +691,13 @@ class AxisParameter(BeamlineParameter):
         self._initialise_setpoint()
         self._initialise_beam_path_sp_listeners()
         self._initialise_beam_path_rbv_listeners()
+
+    def _add_to_parameter_groups(self):
+        super()._add_to_parameter_groups()
+        if self.axis in [ChangeAxis.POSITION, ChangeAxis.ANGLE]:
+            self.group_names.append(BeamlineParameterGroup.COLLIMATION_PLANE)
+        else:
+            self.group_names.append(BeamlineParameterGroup.MISC)
 
     def _update_sp_from_component(self, update: SetRelativeToBeamUpdate):
         new_sp = update.relative_to_beam
@@ -848,6 +856,10 @@ class InBeamParameter(BeamlineParameter):
         self.parameter_type = BeamlineParameterType.IN_OUT
         self.group_names.append(BeamlineParameterGroup.TOGGLE)
 
+    def _add_to_parameter_groups(self):
+        super()._add_to_parameter_groups()
+        self.group_names.append(BeamlineParameterGroup.TOGGLE)
+
     def _initialise_sp_from_file(self):
         """
         Read an autosaved setpoint for this parameter from the autosave file. Remains None if unsuccessful.
@@ -923,15 +935,14 @@ class DirectParameter(BeamlineParameter):
                 parameter to be "at readback value"
             custom_function: custom function to run on move
         """
+        self._pv_wrapper = pv_wrapper
         super(DirectParameter, self).__init__(name, description, autosave, rbv_to_sp_tolerance=rbv_to_sp_tolerance,
                                               custom_function=custom_function)
         self._last_update = None
 
-        self._pv_wrapper = pv_wrapper
         self._pv_wrapper.add_listener(ReadbackUpdate, self._cache_and_update_rbv)
         self._pv_wrapper.add_listener(IsChangingUpdate, self._on_is_changing_change)
         self._pv_wrapper.initialise()
-        self.group_names.append(BeamlineParameterGroup.SLIT)
 
         if self._autosave:
             self._initialise_sp_from_file()
@@ -941,6 +952,10 @@ class DirectParameter(BeamlineParameter):
         self._no_move_because_is_define = False
         self.define_current_value_as = DefineCurrentValueAsParameter(self._pv_wrapper.define_position_as,
                                                                      self._set_sp_perform_no_move, self)
+
+    def _add_to_parameter_groups(self):
+        super()._add_to_parameter_groups()
+        self.group_names.append(BeamlineParameterGroup.SLIT)
 
     def _initialise_sp_from_file(self):
         """
@@ -1042,7 +1057,9 @@ class SlitGapParameter(DirectParameter):
                                                rbv_to_sp_tolerance=rbv_to_sp_tolerance, custom_function=custom_function)
         self.engineering_unit = "mm"
 
-        if pv_wrapper.is_vertical:
+    def _add_to_parameter_groups(self):
+        super()._add_to_parameter_groups()
+        if self._pv_wrapper.is_vertical:
             self.group_names.append(BeamlineParameterGroup.FOOTPRINT_PARAMETER)
 
 
@@ -1069,6 +1086,9 @@ class EnumParameter(BeamlineParameter):
         self.options = options
         if self._autosave:
             self._initialise_sp_from_file()
+
+    def _add_to_parameter_groups(self):
+        super()._add_to_parameter_groups()
         self.group_names.append(BeamlineParameterGroup.TOGGLE)
 
     def validate(self, drivers: List['IocDriver']) -> List[str]:

--- a/ReflectometryServer/test_modules/test_beamline.py
+++ b/ReflectometryServer/test_modules/test_beamline.py
@@ -55,7 +55,7 @@ class TestComponentBeamline(unittest.TestCase):
     def test_GIVEN_beam_line_contains_multiple_component_WHEN_beam_set_THEN_each_component_has_beam_out_which_is_effected_by_each_component_in_turn(self):
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         mirror_position = 10
-        initial_mirror_angle = 45
+        initial_mirror_angle = 22.5
         beamline, mirror = self.setup_beamline(initial_mirror_angle, mirror_position, beam_start)
         bounced_beam = PositionAndAngle(y=0, z=mirror_position, angle=initial_mirror_angle * 2)
         expected_beams = [beam_start, bounced_beam, bounced_beam]
@@ -73,7 +73,7 @@ class TestComponentBeamline(unittest.TestCase):
 
         beamline, mirror = self.setup_beamline(initial_mirror_angle, mirror_position, beam_start)
 
-        mirror_final_angle = 45
+        mirror_final_angle = 22.5
         bounced_beam = PositionAndAngle(y=0, z=mirror_position, angle=mirror_final_angle * 2)
         expected_beams = [beam_start, bounced_beam, bounced_beam]
 
@@ -86,7 +86,7 @@ class TestComponentBeamline(unittest.TestCase):
     def test_GIVEN_beam_line_contains_multiple_component_WHEN_mirror_disabled_THEN_beam_positions_are_all_recalculated(self):
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         mirror_position = 10
-        initial_mirror_angle = 45
+        initial_mirror_angle = 22.5
 
         beamline, mirror = self.setup_beamline(initial_mirror_angle, mirror_position, beam_start)
         expected_beams = [beam_start, beam_start, beam_start]

--- a/ReflectometryServer/test_modules/test_beamline_parameter.py
+++ b/ReflectometryServer/test_modules/test_beamline_parameter.py
@@ -1,3 +1,4 @@
+import math
 import unittest
 from math import isnan
 from time import sleep
@@ -1377,48 +1378,48 @@ class TestReadonlyParameters(unittest.TestCase):
         super_mirror = ReflectingComponent("super mirror", PositionAndAngle(z=self.sm_z, y=0, angle=90))
         self.sm_angle = AxisParameter("sm_angle", super_mirror, ChangeAxis.ANGLE)
         sample = ReflectingComponent("sample", PositionAndAngle(z=self.sm_z + self.sm_to_sa_distance, y=0, angle=90))
-        self.out_beam_y = AxisParameter("out_beam_y", sample, ChangeAxis.DISPLACEMENT_POSITION)
-        self.out_beam_angle = AxisParameter("out_beam_angle", sample, ChangeAxis.DISPLACEMENT_ANGLE)
-        params = [self.sm_angle, self.out_beam_y, self.out_beam_angle]
+        self.displacement_height = AxisParameter("displacement_height", sample, ChangeAxis.DISPLACEMENT_POSITION)
+        self.displacement_angle = AxisParameter("displacement_angle", sample, ChangeAxis.DISPLACEMENT_ANGLE)
+        params = [self.sm_angle, self.displacement_height, self.displacement_angle]
         mode = BeamlineMode("mode name", [param.name for param in params])
         self.beamline = Beamline([super_mirror, sample], params, [], [mode])
 
     def test_GIVEN_incoming_beam_has_changed_but_not_moved_THEN_outgoing_beam_param_sp_rbv_is_not_updated(self):
-        assert_that(self.out_beam_angle.sp, is_(0))
-        assert_that(self.out_beam_y.sp, is_(0))
+        assert_that(self.displacement_angle.sp, is_(0))
+        assert_that(self.displacement_height.sp, is_(0))
         expected_angle = 0
         expected_y = 0
 
         self.sm_angle.sp_no_move = self.sm_angle_to_set
-        actual_y = self.out_beam_y.sp_rbv
-        actual_angle = self.out_beam_angle.sp_rbv
+        actual_y = self.displacement_height.sp_rbv
+        actual_angle = self.displacement_angle.sp_rbv
 
         assert_that(actual_y, is_(close_to(expected_y, DEFAULT_TEST_TOLERANCE)))
         assert_that(actual_angle, is_(expected_angle))
 
     def test_GIVEN_incoming_beam_has_changed_WHEN_moving_THEN_outgoing_beam_param_sp_is_updated(self):
-        assert_that(self.out_beam_angle.sp, is_(0))
-        assert_that(self.out_beam_y.sp, is_(0))
+        assert_that(self.displacement_angle.sp, is_(0))
+        assert_that(self.displacement_height.sp, is_(0))
         expected_angle = self.updated_angle
         expected_y = self.updated_y
 
         self.sm_angle.sp = self.sm_angle_to_set
-        actual_y = self.out_beam_y.sp
-        actual_angle = self.out_beam_angle.sp
+        actual_y = self.displacement_height.sp
+        actual_angle = self.displacement_angle.sp
 
         assert_that(actual_y, is_(close_to(expected_y, DEFAULT_TEST_TOLERANCE)))
         assert_that(actual_angle, is_(expected_angle))
 
     def test_GIVEN_incoming_beam_has_changed_WHEN_moving_THEN_outgoing_beam_param_sp_rbv_is_updated(self):
         initial_value = 0
-        assert_that(self.out_beam_angle.sp, is_(initial_value))
-        assert_that(self.out_beam_y.sp, is_(initial_value))
+        assert_that(self.displacement_angle.sp, is_(initial_value))
+        assert_that(self.displacement_height.sp, is_(initial_value))
         expected_angle = self.updated_angle
         expected_y = self.updated_y
 
         self.sm_angle.sp = self.sm_angle_to_set
-        actual_y = self.out_beam_y.sp_rbv
-        actual_angle = self.out_beam_angle.sp_rbv
+        actual_y = self.displacement_height.sp_rbv
+        actual_angle = self.displacement_angle.sp_rbv
 
         assert_that(actual_y, is_(close_to(expected_y, DEFAULT_TEST_TOLERANCE)))
         assert_that(actual_angle, is_(expected_angle))

--- a/ReflectometryServer/test_modules/test_beamline_parameter.py
+++ b/ReflectometryServer/test_modules/test_beamline_parameter.py
@@ -202,6 +202,46 @@ class TestBeamlineParameter(unittest.TestCase):
 
         assert_that(result, is_(False))
 
+    @parameterized.expand([ChangeAxis.OUT_BEAM_Y, ChangeAxis.OUT_BEAM_Z, ChangeAxis.OUT_BEAM_ANGLE])
+    def test_GIVEN_beam_out_parameter_WHEN_setting_sp_THEN_sp_ignored(self, change_axis):
+        sample = ReflectingComponent("sample", setup=PositionAndAngle(0, 0, 90))
+        beam_out_y = AxisParameter("beam_out_y", sample, change_axis)
+        expected = None
+
+        beam_out_y.sp = 5
+        actual = beam_out_y.sp
+
+        assert_that(actual, is_(expected))
+
+    @parameterized.expand([ChangeAxis.OUT_BEAM_Y, ChangeAxis.OUT_BEAM_Z, ChangeAxis.OUT_BEAM_ANGLE])
+    def test_GIVEN_read_only_parameter_WHEN_setting_sp_no_action_THEN_sp_not_set(self, change_axis):
+        sample = ReflectingComponent("sample", setup=PositionAndAngle(0, 0, 90))
+        beam_out_y = AxisParameter("beam_out_y", sample, change_axis)
+        expected = None
+
+        beam_out_y.sp_no_move = 5
+        actual = beam_out_y.sp
+
+        assert_that(actual, is_(expected))
+
+    # def test_GIVEN_read_only_parameter_WHEN_param_has_mode_inits_THEN_inits_ignored(self):
+    #     expected = None
+    #     param_init = 5.0
+    #     sample = ReflectingComponent("sample", setup=PositionAndAngle(0, 0, 90))
+    #
+    #     out_y = AxisParameter("out_y", sample, ChangeAxis.OUT_BEAM_Y)
+    #     out_z = AxisParameter("out_z", sample, ChangeAxis.OUT_BEAM_Z)
+    #     out_ang = AxisParameter("out_ang", sample, ChangeAxis.OUT_BEAM_ANG)
+    #     sp_inits = {sample_param.name: param_init}
+    #     beamline_mode = BeamlineMode("mode name", [sample_param.name], sp_inits)
+    #     beamline = Beamline([sample_comp], [sample_param], [], [beamline_mode])
+    #
+    #     beamline.active_mode = beamline_mode.name
+    #
+    #     assert_that(smangle.sp, is_(sm_angle_to_set))
+    #     assert_that(smangle.sp_changed, is_(True))
+    #     assert_that(sample_comp.beam_path_set_point.axis[ChangeAxis.ANGLE].get_displacement(), is_(sm_angle))
+
 
 class TestBeamlineParametersThoseRBVMirrosSP(unittest.TestCase):
 
@@ -1323,6 +1363,49 @@ class TestCustomFunctionCall(unittest.TestCase):
         sleep(0.1)  # wait for thread to run
 
         mock_func.assert_called_with(expected_sp, expected_original_sp)
+
+
+class TestReadonlyParameters(unittest.TestCase):
+
+    def setUp(self):
+        super_mirror = ReflectingComponent("super mirror", PositionAndAngle(z=10, y=0, angle=90))
+        self.sm_angle = AxisParameter("sm_angle", super_mirror, ChangeAxis.ANGLE)
+        sample = TiltingComponent("sample", PositionAndAngle(z=20, y=0, angle=90))
+        self.out_beam_y = AxisParameter("out_beam_y", sample, ChangeAxis.OUT_BEAM_Y)
+        self.out_beam_z = AxisParameter("out_beam_z", sample, ChangeAxis.OUT_BEAM_Z)
+        self.out_beam_angle = AxisParameter("out_beam_angle", sample, ChangeAxis.OUT_BEAM_ANGLE)
+        params = [self.sm_angle, self.out_beam_y, self.out_beam_z, self.out_beam_angle]
+        mode = BeamlineMode("mode name", [param.name for param in params])
+        self.beamline = Beamline([super_mirror, sample], params, [], [mode])
+
+        # parameter.sp_no_move = setpoint
+        # beamline.active_mode = mode.name
+        # beamline.move = 1
+
+    def test_GIVEN_incoming_beam_has_changed_THEN_outgoing_beam_param_sp_is_updated(self):
+        initial_angle = self.out_beam_angle.sp
+        assert_that(initial_angle, is_(0))
+        sm_angle_to_set = 22.5
+        expected_angle = 2*sm_angle_to_set
+
+        self.sm_angle.sp = sm_angle_to_set
+
+        actual_angle = self.out_beam_angle.sp
+
+        assert_that(actual_angle, is_(expected_angle))
+
+    def test_GIVEN_incoming_beam_has_changed_THEN_outgoing_beam_param_sp_rbv_is_updated(self):
+        # SPRBV need to update automatically because they cannot be applied by move
+        sm_angle_to_set = 22.5
+        expected_y = 0  # equal to distance between mirror and sample because of 45 deg reflection angle
+        expected_angle = 2*sm_angle_to_set
+        self.sm_angle.sp = sm_angle_to_set
+
+        actual_y = self.out_beam_y.sp_rbv
+        actual_angle = self.out_beam_angle.sp_rbv
+
+        assert_that(actual_y, is_(close_to(expected_y, DEFAULT_TEST_TOLERANCE)))
+        assert_that(actual_angle, is_(expected_angle))
 
 
 if __name__ == '__main__':

--- a/ReflectometryServer/test_modules/test_components.py
+++ b/ReflectometryServer/test_modules/test_components.py
@@ -882,7 +882,7 @@ class TestComponentDisablingAndAutosaveInit(unittest.TestCase):
     def test_GIVEN_component_WHEN_init_disabled_with_invalid_beam_THEN_incoming_beam_is_0_0_0(self, mock_auto_save):
         expected_incoming_beam = PositionAndAngle(0, 0, 0)
         mock_auto_save.read_parameter.return_value = None
-        component = Component("comp", PositionAndAngle(0, 0, 0))
+        component = Component("comp", PositionAndAngle(0, 10, 90))
 
         component.set_incoming_beam_can_change(False, on_init=True)
 
@@ -903,7 +903,7 @@ class TestComponentDisablingAndAutosaveInit(unittest.TestCase):
         expected_incoming_beam_sp = PositionAndAngle(1, 2, 3)
         expected_incoming_beam_rbv = PositionAndAngle(1, 2, 3)
         expected_name = "comp"
-        component = Component(expected_name, PositionAndAngle(0, 0, 0))
+        component = Component(expected_name, PositionAndAngle(0, 10, 90))
         component.beam_path_set_point.set_incoming_beam(PositionAndAngle(0,0,0))
         component.beam_path_rbv.set_incoming_beam(PositionAndAngle(0,0,0))
         component.set_incoming_beam_can_change(False)

--- a/ReflectometryServer/test_modules/test_config_helper.py
+++ b/ReflectometryServer/test_modules/test_config_helper.py
@@ -41,9 +41,9 @@ class TestConfigHelper(unittest.TestCase):
         assert_that(result.beamline_constants, only_contains(expected_constant1, expected_constant2, expected_constant3))
 
     def test_GIVEN_beam_line_components_added_WHEN_get_beamline_THEN_beam_line_has_components(self):
-        expected1 = Component("1", PositionAndAngle(0, 0, 0))
-        expected2 = Component("2", PositionAndAngle(0, 0, 0))
-        expected3 = Component("3", PositionAndAngle(0, 0, 0))
+        expected1 = Component("1", PositionAndAngle(0, 10, 90))
+        expected2 = Component("2", PositionAndAngle(0, 20, 90))
+        expected3 = Component("3", PositionAndAngle(0, 30, 90))
 
         add_component(expected1)
         add_component(expected2)
@@ -319,7 +319,7 @@ class TestConfigHelper(unittest.TestCase):
     def test_GVIEN_add_beam_start_WHEN_get_beamline_THEN_beam_start_is_correct(self):
         add_mode("NR")
         expected_beam_start = PositionAndAngle(0.0, -10.0, 0.0)
-        comp = add_component(Component("name", PositionAndAngle(0, 0, 0)))
+        comp = add_component(Component("name", PositionAndAngle(0, 0, 90)))
         add_beam_start(expected_beam_start)
 
         result = get_configured_beamline()

--- a/ReflectometryServer/test_modules/test_driver_utils.py
+++ b/ReflectometryServer/test_modules/test_driver_utils.py
@@ -48,6 +48,7 @@ class TestDriverUtils(unittest.TestCase):
                                                 ("{}:ACTION".format(pvname), 0, AlarmSeverity.No, AlarmSeverity.No),
                                                 ("{}:RBV:AT_SP".format(pvname), True, AlarmSeverity.No, AlarmSeverity.No),
                                                 ("{}:LOCKED".format(pvname), False, AlarmSeverity.No, AlarmSeverity.No),
+                                                ("{}:READ_ONLY".format(pvname), False, AlarmSeverity.No, AlarmSeverity.No),
                                                 ))
 
     def test_GIVEN_enum_param_WHEN_update_event_processed_using_get_param_update_from_event_THEN_fields_(self):


### PR DESCRIPTION
Added new Axis types for AxisParameter (`DISPLACEMENT_HEIGHT`, `DISPLACEMENT_ANGLE`). These are different from existing parameters as their setpoints cannot be set explicitly, instead they take the displacement positions calculated internally by the reflectometry server for the parent component based on the current beam path. 

Ticket: https://github.com/ISISComputingGroup/IBEX/issues/7649